### PR TITLE
Add column widths with table data attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -266,6 +266,12 @@ module.exports = function(htmlText, options) {
                 ret.table.body.push([re]);
               }
             });
+            if (element.dataset && element.dataset.widths) {
+              var widthsStr = element.dataset.widths;
+              var widths = JSON.parse(widthsStr.replace(new RegExp("'", 'g'), '"'));
+              if (Array.isArray(widths) && ret.table.body.length > 0 && ret.table.body[0].length <= widths.length)
+                ret.table.widths = widths;
+            }
             delete ret._;
             // check if the element has a "style" attribute
             setComputedStyle(ret, element.getAttribute("style"));

--- a/test/unit.js
+++ b/test/unit.js
@@ -450,6 +450,73 @@ test("table (colspan + empty cell)", function(t) {
   t.finish();
 })
 
+test("table (column widths)",function(t) {
+  var html = `<table data-widths='[100, "*", "auto"]'>
+      <tr>
+        <td>Cell1</td>
+        <td>Cell2</td>
+        <td>Cell3</td>
+      </tr>
+  </table>`;
+  var ret = htmlToPdfMake(html, window);
+  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
+  ret = ret[0];
+  t.check(
+    ret.table &&
+    'widths' in ret.table &&
+    Array.isArray(ret.table.widths) &&
+    ret.table.widths.length === 3 &&
+    ret.table.widths[0] === 100 &&
+    ret.table.widths[1] === "*" &&
+    ret.table.widths[2] === "auto",
+  "table (column widths)");
+
+  t.finish();
+})
+
+test("table (column widths escaped)",function(t) {
+  var html = `<table data-widths="[100, '*', 'auto']">
+      <tr>
+        <td>Cell1</td>
+        <td>Cell2</td>
+        <td>Cell3</td>
+      </tr>
+  </table>`;
+  var ret = htmlToPdfMake(html, window);
+  t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+  ret = ret[0];
+  t.check(
+    ret.table &&
+    'widths' in ret.table &&
+    Array.isArray(ret.table.widths) &&
+    ret.table.widths.length === 3 &&
+    ret.table.widths[0] === 100 &&
+    ret.table.widths[1] === "*" &&
+    ret.table.widths[2] === "auto",
+  "table (column widths escaped)");
+
+  t.finish();
+})
+
+test("table (column widths wrong lengths)",function(t) {
+  var html = `<table data-widths='[100, "*"]'>
+      <tr>
+        <td>Cell1</td>
+        <td>Cell2</td>
+        <td>Cell3</td>
+      </tr>
+  </table>`;
+  var ret = htmlToPdfMake(html, window);
+  t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+  ret = ret[0];
+  t.check(
+    ret.table &&
+    !('widths' in ret.table),
+  "table (column widths wrong lengths)");
+
+  t.finish();
+})
+
 test("img",function(t) {
   var ret = htmlToPdfMake('<img width="10" style="height:10px" src="data:image/jpeg;base64,...encodedContent...">', window);
   t.check(Array.isArray(ret) && ret.length===1, "return is OK");


### PR DESCRIPTION
We needed to add a column widths in HTML template. 

You can supply the column widths in table attribute data-widths.
it's either `<table data-widths="[100,'*','auto']">` or `<table data-widths='[100,"*","auto"]'>`, it will be parsed as JSON. The length of the array must be greater or equal to the number of columns in table.