### PR TITLE
Support for type attribute on ol and ul elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,17 @@ module.exports = function(htmlText, options) {
 
   var inlineTags = [ 'p', 'li', 'span', 'strong', 'em', 'b', 'i', 'u', 'th', 'td' ];
 
+  var listTypes = {
+    'a': 'lower-alpha',
+    'A': 'upper-alpha',
+    'i': 'lower-roman',
+    'I': 'upper-roman',
+    '1': 'decimal',
+    'circle': 'circle',
+    'square': 'square',
+    'disc': 'disc'
+  };
+
   /**
    * Permit to change the default styles based on the options
    * @return {[type]} [description]
@@ -200,6 +211,11 @@ module.exports = function(htmlText, options) {
             }
             // check if the element has a "style" attribute
             setComputedStyle(ret, element.getAttribute("style"));
+            // set list type if present
+            var listType = element.getAttribute('type');
+            if (listType && listTypes[listType]) {
+              ret.type = listTypes[listType];
+            }
             break;
           }
           case "table":{

--- a/test/unit.js
+++ b/test/unit.js
@@ -190,6 +190,30 @@ test("a",function(t) {
   t.finish();
 })
 
+test("ol without type",function(t) {
+  var ret = htmlToPdfMake('<ol><li>Numbered list</li></ol>', window);
+  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
+  ret = ret[0];
+  t.check(
+    !ret.hasOwnProperty("type") &&
+    Array.isArray(ret.ol) && ret.ol[0].text === "Numbered list",
+  "<ol>");
+
+  t.finish();
+})
+
+test("ol with type",function(t) {
+  var ret = htmlToPdfMake('<ol type="a"><li>Numbered list</li></ol>', window);
+  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
+  ret = ret[0];
+  t.check(
+    ret.type === "lower-alpha" &&
+    Array.isArray(ret.ol) && ret.ol[0].text === "Numbered list",
+  "<ol type='a'>");
+
+  t.finish();
+})
+
 // { text: 'strike', decoration: 'lineThrough', style: [ 'html-strike' ] }
 test("strike",function(t) {
   var ret = htmlToPdfMake("<strike>strike</strike>", window);


### PR DESCRIPTION
This branch adds support for the `type` attribute on `<ol>` and `<ul>` elements.

Note that it does not add support for overriding the list type on individual `<li>` elements.