### PR TITLE
Added support for HTML 4's font element

### DIFF
--- a/index.js
+++ b/index.js
@@ -428,12 +428,8 @@ module.exports = function (htmlText, options) {
 								Math.max(1, parseInt(element.getAttribute("size"))),
 								7
 							);
-
-							// Getting the relatiev fontsize
-							var fontSize = Math.min(
-								fontSizes[6],
-								Math.max(fontSizes[0], fontSizes[size - 1])
-							);
+							// Getting the relative fontsize
+							var fontSize = Math.max(fontSizes[0], fontSizes[size - 1]);
 
 							// Assigning the font size
 							ret.fontSize = fontSize;

--- a/index.js
+++ b/index.js
@@ -35,6 +35,13 @@
 //var util = require("util"); // to debug
 module.exports = function (htmlText, options) {
 	var wndw = options && options.window ? options.window : window;
+
+	// Used with the size attribute on the font elements to calculate relative font size
+	var fontSizes =
+		options && Array.isArray(options.fontSizes)
+			? options.fontSizes
+			: [10, 14, 16, 18, 20, 24, 28];
+
 	var tableAutoSize =
 		options && typeof options.tableAutoSize === "boolean"
 			? options.tableAutoSize
@@ -408,13 +415,35 @@ module.exports = function (htmlText, options) {
 						break;
 					}
 					case "FONT": {
+						// Checking if the element has a color attribute
 						if (element.getAttribute("color")) {
+							// Assinging the color
 							ret.color = parseColor(element.getAttribute("color"));
-							ret = applyStyle({
-								ret: ret,
-								parents: parents.concat([element]),
-							});
 						}
+
+						// Checking if the element has a size attribute
+						if (element.getAttribute("size")) {
+							// Getting and sanitizing the size value
+							var size = Math.min(
+								Math.max(1, parseInt(element.getAttribute("size"))),
+								7
+							);
+
+							// Getting the relatiev fontsize
+							var fontSize = Math.min(
+								fontSizes[6],
+								Math.max(fontSizes[0], fontSizes[size - 1])
+							);
+
+							// Assigning the font size
+							ret.fontSize = fontSize;
+						}
+
+						// Applying inherited styles
+						ret = applyStyle({
+							ret: ret,
+							parents: parents.concat([element]),
+						});
 						break;
 					}
 				}

--- a/index.js
+++ b/index.js
@@ -33,642 +33,767 @@
  * });
  */
 //var util = require("util"); // to debug
-module.exports = function(htmlText, options) {
-  var wndw = (options && options.window ? options.window : window);
-  var tableAutoSize = (options && typeof options.tableAutoSize === "boolean" ? options.tableAutoSize : false);
+module.exports = function (htmlText, options) {
+	var wndw = options && options.window ? options.window : window;
+	var tableAutoSize =
+		options && typeof options.tableAutoSize === "boolean"
+			? options.tableAutoSize
+			: false;
 
-  // set default styles
-  var defaultStyles = {
-    b: {bold:true},
-    strong: {bold:true},
-    u: {decoration:'underline'},
-    del: {decoration:'lineThrough'},
-    s: {decoration: 'lineThrough'},
-    em: {italics:true},
-    i: {italics:true},
-    h1: {fontSize:24, bold:true, marginBottom:5},
-    h2: {fontSize:22, bold:true, marginBottom:5},
-    h3: {fontSize:20, bold:true, marginBottom:5},
-    h4: {fontSize:18, bold:true, marginBottom:5},
-    h5: {fontSize:16, bold:true, marginBottom:5},
-    h6: {fontSize:14, bold:true, marginBottom:5},
-    a: {color:'blue', decoration:'underline'},
-    strike: {decoration: 'lineThrough'},
-    p: {margin:[0, 5, 0, 10]},
-    ul: {marginBottom:5,marginLeft:5},
-    table: {marginBottom:5},
-    th: {bold:true, fillColor:'#EEEEEE'}
-  }
+	// set default styles
+	var defaultStyles = {
+		b: { bold: true },
+		strong: { bold: true },
+		u: { decoration: "underline" },
+		del: { decoration: "lineThrough" },
+		s: { decoration: "lineThrough" },
+		em: { italics: true },
+		i: { italics: true },
+		h1: { fontSize: 24, bold: true, marginBottom: 5 },
+		h2: { fontSize: 22, bold: true, marginBottom: 5 },
+		h3: { fontSize: 20, bold: true, marginBottom: 5 },
+		h4: { fontSize: 18, bold: true, marginBottom: 5 },
+		h5: { fontSize: 16, bold: true, marginBottom: 5 },
+		h6: { fontSize: 14, bold: true, marginBottom: 5 },
+		a: { color: "blue", decoration: "underline" },
+		strike: { decoration: "lineThrough" },
+		p: { margin: [0, 5, 0, 10] },
+		ul: { marginBottom: 5, marginLeft: 5 },
+		table: { marginBottom: 5 },
+		th: { bold: true, fillColor: "#EEEEEE" },
+	};
 
-  /**
-   * Permit to change the default styles based on the options
-   */
-  function changeDefaultStyles () {
-    for (var keyStyle in options.defaultStyles) {
-      if (defaultStyles.hasOwnProperty(keyStyle)) {
-        // if we want to remove a default style
-        if (options.defaultStyles.hasOwnProperty(keyStyle) && !options.defaultStyles[keyStyle]) {
-          delete defaultStyles[keyStyle];
-        } else {
-          for (var k in options.defaultStyles[keyStyle]) {
-            // if we want to delete a specific property
-            if (!options.defaultStyles[keyStyle][k]) delete defaultStyles[keyStyle][k];
-            else defaultStyles[keyStyle][k] = options.defaultStyles[keyStyle][k];
-          }
-        }
-      }
-    }
-  }
+	/**
+	 * Permit to change the default styles based on the options
+	 */
+	function changeDefaultStyles() {
+		for (var keyStyle in options.defaultStyles) {
+			if (defaultStyles.hasOwnProperty(keyStyle)) {
+				// if we want to remove a default style
+				if (
+					options.defaultStyles.hasOwnProperty(keyStyle) &&
+					!options.defaultStyles[keyStyle]
+				) {
+					delete defaultStyles[keyStyle];
+				} else {
+					for (var k in options.defaultStyles[keyStyle]) {
+						// if we want to delete a specific property
+						if (!options.defaultStyles[keyStyle][k])
+							delete defaultStyles[keyStyle][k];
+						else
+							defaultStyles[keyStyle][k] = options.defaultStyles[keyStyle][k];
+					}
+				}
+			}
+		}
+	}
 
-  if (options && options.defaultStyles) {
-    changeDefaultStyles();
-  }
+	if (options && options.defaultStyles) {
+		changeDefaultStyles();
+	}
 
-  /**
-   * Takes an HTML string, converts to HTML using a DOM parser and recursivly parses
-   * the content into pdfmake compatible doc definition
-   *
-   * @param htmlText the html text to translate as string
-   * @returns pdfmake doc definition as object
-   */
-  var convertHtml = function(htmlText) {
-    // Create a HTML DOM tree out of html string
-    var parser = new wndw.DOMParser();
-    var parsedHtml = parser.parseFromString(htmlText, 'text/html');
+	/**
+	 * Takes an HTML string, converts to HTML using a DOM parser and recursivly parses
+	 * the content into pdfmake compatible doc definition
+	 *
+	 * @param htmlText the html text to translate as string
+	 * @returns pdfmake doc definition as object
+	 */
+	var convertHtml = function (htmlText) {
+		// Create a HTML DOM tree out of html string
+		var parser = new wndw.DOMParser();
+		var parsedHtml = parser.parseFromString(htmlText, "text/html");
 
-    var docDef = parseElement(parsedHtml.body, []);
-    // remove first level
-    return  docDef.stack || docDef.text;
-  }
+		var docDef = parseElement(parsedHtml.body, []);
+		// remove first level
+		return docDef.stack || docDef.text;
+	};
 
-  /**
-   * Converts a single HTML element to pdfmake, calls itself recursively for child html elements
-   *
-   * @param element can be an HTML element (<p>) or plain text ("Hello World")
-   * @param parentNode the parent node for the current element
-   * @param parents Array of node names of all the parents for the element
-   * @returns the doc def to the given element in consideration to the given paragraph and styles
-   */
-  var parseElement = function(element, parents) {
-    var nodeName = element.nodeName.toUpperCase();
-    var nodeNameLowerCase = nodeName.toLowerCase();
-    var ret = {text:[]};
-    var text, needStack=false;
-    var dataset, i, key;
+	/**
+	 * Converts a single HTML element to pdfmake, calls itself recursively for child html elements
+	 *
+	 * @param element can be an HTML element (<p>) or plain text ("Hello World")
+	 * @param parentNode the parent node for the current element
+	 * @param parents Array of node names of all the parents for the element
+	 * @returns the doc def to the given element in consideration to the given paragraph and styles
+	 */
+	var parseElement = function (element, parents) {
+		var nodeName = element.nodeName.toUpperCase();
+		var nodeNameLowerCase = nodeName.toLowerCase();
+		var ret = { text: [] };
+		var text,
+			needStack = false;
+		var dataset, i, key;
 
-    // ignore some HTML tags
-    if (['COLGROUP','COL'].indexOf(nodeName) > -1) return '';
+		// ignore some HTML tags
+		if (["COLGROUP", "COL"].indexOf(nodeName) > -1) return "";
 
-    switch(element.nodeType) {
-      case 3: { // TEXT_NODE
-        if (element.textContent) {
-          text = element.textContent.replace(/\n(\s+)?/g, "");
+		switch (element.nodeType) {
+			case 3: {
+				// TEXT_NODE
+				if (element.textContent) {
+					text = element.textContent.replace(/\n(\s+)?/g, "");
 
-          // for table, thead, tbody, tfoot, tr: remove all empty space
-          if (['TABLE','THEAD','TBODY','TFOOT','TR'].indexOf(parents[parents.length-1].nodeName) > -1) text = text.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
-          if (text) {
-            ret = {'text':text};
-            ret = applyStyle({ret:ret, parents:parents});
-            return ret;
-          }
-        }
+					// for table, thead, tbody, tfoot, tr: remove all empty space
+					if (
+						["TABLE", "THEAD", "TBODY", "TFOOT", "TR"].indexOf(
+							parents[parents.length - 1].nodeName
+						) > -1
+					)
+						text = text.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, "");
+					if (text) {
+						ret = { text: text };
+						ret = applyStyle({ ret: ret, parents: parents });
+						return ret;
+					}
+				}
 
-        return '';
-      }
-      case 1: { // ELEMENT_NODE
-        ret.nodeName = nodeName;
-        parents.push(element);
-        if (element.childNodes && element.childNodes.length>0) {
-          [].forEach.call(element.childNodes, function(child) {
-            var res = parseElement(child, parents);
-            if (res) {
-              if (Array.isArray(res.text) && res.text.length===0) res.text='';
-              ret.text.push(res);
-            }
-          });
-          //console.log(nodeName,'=>',util.inspect(ret.text, {showHidden: false, depth: null})); // to debug
-          // find if we need a 'stack' instead of a 'text'
-          needStack = searchForStack(ret);
-          if (needStack) {
-            ret.stack = ret.text.slice(0);
-            delete ret.text;
-          } else {
-            // apply all the inhirent classes and styles from the parents
-            ret = applyStyle({ret:ret, parents:parents});
-          }
-        }
-        parents.pop();
+				return "";
+			}
+			case 1: {
+				// ELEMENT_NODE
+				ret.nodeName = nodeName;
+				parents.push(element);
+				if (element.childNodes && element.childNodes.length > 0) {
+					[].forEach.call(element.childNodes, function (child) {
+						var res = parseElement(child, parents);
+						if (res) {
+							if (Array.isArray(res.text) && res.text.length === 0)
+								res.text = "";
+							ret.text.push(res);
+						}
+					});
+					//console.log(nodeName,'=>',util.inspect(ret.text, {showHidden: false, depth: null})); // to debug
+					// find if we need a 'stack' instead of a 'text'
+					needStack = searchForStack(ret);
+					if (needStack) {
+						ret.stack = ret.text.slice(0);
+						delete ret.text;
+					} else {
+						// apply all the inhirent classes and styles from the parents
+						ret = applyStyle({ ret: ret, parents: parents });
+					}
+				}
+				parents.pop();
 
-        switch(nodeName) {
-          case "TABLE":{
-            var rowIndex, cellIndex;
-            // the format for the table is table.body[[], [], …]
-            ret.table = {body:[]};
-            var tbodies = (ret.stack || ret.text);
-            if (Array.isArray(tbodies)) {
-              rowIndex = 0;
-              // Array with All Rows including THEAD
-              var allRows = [];
-              // for each THEAD / TBODY
-              tbodies.forEach(function(tbody) {
-                // for each row
-                var rows = (tbody.stack || tbody.text);
-                if (Array.isArray(rows)) {
-                  // Add rows to allRows
-                  allRows = allRows.concat(rows);
-                  rows.forEach(function(row) {
-                    var cells = (row.stack || row.text);
-                    // for each cell
-                    if (Array.isArray(cells)) {
-                      cellIndex = 0;
-                      ret.table.body[rowIndex] = [];
-                      cells.forEach(function(cell) {
-                        ret.table.body[rowIndex].push(cell);
+				switch (nodeName) {
+					case "TABLE": {
+						var rowIndex, cellIndex;
+						// the format for the table is table.body[[], [], …]
+						ret.table = { body: [] };
+						var tbodies = ret.stack || ret.text;
+						if (Array.isArray(tbodies)) {
+							rowIndex = 0;
+							// Array with All Rows including THEAD
+							var allRows = [];
+							// for each THEAD / TBODY
+							tbodies.forEach(function (tbody) {
+								// for each row
+								var rows = tbody.stack || tbody.text;
+								if (Array.isArray(rows)) {
+									// Add rows to allRows
+									allRows = allRows.concat(rows);
+									rows.forEach(function (row) {
+										var cells = row.stack || row.text;
+										// for each cell
+										if (Array.isArray(cells)) {
+											cellIndex = 0;
+											ret.table.body[rowIndex] = [];
+											cells.forEach(function (cell) {
+												ret.table.body[rowIndex].push(cell);
 
-                        // do we have a colSpan?
-                        // if yes, insert empty cells due to colspan
-                        if (cell.colSpan) {
-                          i = cell.colSpan;
-                          // do we have a rowSpan in addition of the colSpan?
-                          setRowSpan({rows:allRows, cell:cell, rowIndex:rowIndex, cellIndex:cellIndex});
-                          while (--i > 0) {
-                            ret.table.body[rowIndex].push({text:''});
-                            // keep adding empty cell due to rowspan
-                            setRowSpan({rows:allRows, cell:cell, rowIndex:rowIndex, cellIndex:cellIndex});
-                            cellIndex++;
-                          }
-                        } else {
-                          // do we have a rowSpan ?
-                          setRowSpan({rows:allRows, cell:cell, rowIndex:rowIndex, cellIndex:cellIndex});
-                        }
+												// do we have a colSpan?
+												// if yes, insert empty cells due to colspan
+												if (cell.colSpan) {
+													i = cell.colSpan;
+													// do we have a rowSpan in addition of the colSpan?
+													setRowSpan({
+														rows: allRows,
+														cell: cell,
+														rowIndex: rowIndex,
+														cellIndex: cellIndex,
+													});
+													while (--i > 0) {
+														ret.table.body[rowIndex].push({ text: "" });
+														// keep adding empty cell due to rowspan
+														setRowSpan({
+															rows: allRows,
+															cell: cell,
+															rowIndex: rowIndex,
+															cellIndex: cellIndex,
+														});
+														cellIndex++;
+													}
+												} else {
+													// do we have a rowSpan ?
+													setRowSpan({
+														rows: allRows,
+														cell: cell,
+														rowIndex: rowIndex,
+														cellIndex: cellIndex,
+													});
+												}
 
-                        cellIndex++;
-                      });
-                      rowIndex++;
-                    }
-                 });
-                }
-              });
-            }
+												cellIndex++;
+											});
+											rowIndex++;
+										}
+									});
+								}
+							});
+						}
 
-            delete ret.stack;
-            delete ret.text;
-            // apply all the inhirent classes and styles from the parents, or for the current element
-            ret = applyStyle({ret:ret, parents:parents.concat([element])});
+						delete ret.stack;
+						delete ret.text;
+						// apply all the inhirent classes and styles from the parents, or for the current element
+						ret = applyStyle({ ret: ret, parents: parents.concat([element]) });
 
-            // if option tableAutoSize, then we try to apply the correct width/height on the table
-            if (tableAutoSize) {
-              var cellsWidths = [];
-              var cellsHeights = [];
-              var tableWidths = [];
-              var tableHeights = [];
+						// if option tableAutoSize, then we try to apply the correct width/height on the table
+						if (tableAutoSize) {
+							var cellsWidths = [];
+							var cellsHeights = [];
+							var tableWidths = [];
+							var tableHeights = [];
 
-              ret.table.body.forEach(function(row, rowIndex) {
-                cellsWidths.push([]);
-                cellsHeights.push([]);
-                row.forEach(function(cell) {
-                  // we want to remember the different sizes
-                  var width = typeof cell.width !== 'undefined' ? cell.width : 'auto';
-                  var height = typeof cell.height !== 'undefined' ? cell.height : 'auto';
-                  // check if we have colspan or rowspan
-                  // if yes, and if width/height is a number, we divide by the col/rowspan, otherwise we use 'auto'
-                  if (width !== 'auto' && cell.colSpan) {
-                    if (!isNaN(width)) width /= cell.colSpan;
-                    else width = 'auto';
-                  }
-                  if (height !== 'auto' && cell.rowSpan) {
-                    if (!isNaN(height)) height /= cell.colSpan;
-                    else height = 'auto';
-                  }
-                  cellsWidths[rowIndex].push(width);
-                  cellsHeights[rowIndex].push(height);
-                });
-              });
+							ret.table.body.forEach(function (row, rowIndex) {
+								cellsWidths.push([]);
+								cellsHeights.push([]);
+								row.forEach(function (cell) {
+									// we want to remember the different sizes
+									var width =
+										typeof cell.width !== "undefined" ? cell.width : "auto";
+									var height =
+										typeof cell.height !== "undefined" ? cell.height : "auto";
+									// check if we have colspan or rowspan
+									// if yes, and if width/height is a number, we divide by the col/rowspan, otherwise we use 'auto'
+									if (width !== "auto" && cell.colSpan) {
+										if (!isNaN(width)) width /= cell.colSpan;
+										else width = "auto";
+									}
+									if (height !== "auto" && cell.rowSpan) {
+										if (!isNaN(height)) height /= cell.colSpan;
+										else height = "auto";
+									}
+									cellsWidths[rowIndex].push(width);
+									cellsHeights[rowIndex].push(height);
+								});
+							});
 
-              // determine the max width for each cell
-              cellsWidths.forEach(function(row) {
-                row.forEach(function(cellWidth, cellIndex) {
-                  var type = typeof tableWidths[cellIndex];
-                  if (type === "undefined" || (cellWidth !== 'auto' && type === "number" && cellWidth > tableWidths[cellIndex]) || (cellWidth !== 'auto' && tableWidths[cellIndex] === 'auto')) {
-                    tableWidths[cellIndex] = cellWidth;
-                  }
-                });
-              });
-              // determine the max height for each row
-              cellsHeights.forEach(function(row, rowIndex) {
-                row.forEach(function(cellHeight) {
-                  var type = typeof tableHeights[rowIndex];
-                  if (type === "undefined" || (cellHeight !== 'auto' && type === "number" && cellHeight > tableHeights[rowIndex]) || (cellHeight !== 'auto' && tableHeights[rowIndex] === 'auto')) {
-                    tableHeights[rowIndex] = cellHeight;
-                  }
-                });
-              });
-              if (tableWidths.length > 0) ret.table.widths = tableWidths;
-              if (tableHeights.length > 0) ret.table.heights = tableHeights;
-            }
+							// determine the max width for each cell
+							cellsWidths.forEach(function (row) {
+								row.forEach(function (cellWidth, cellIndex) {
+									var type = typeof tableWidths[cellIndex];
+									if (
+										type === "undefined" ||
+										(cellWidth !== "auto" &&
+											type === "number" &&
+											cellWidth > tableWidths[cellIndex]) ||
+										(cellWidth !== "auto" && tableWidths[cellIndex] === "auto")
+									) {
+										tableWidths[cellIndex] = cellWidth;
+									}
+								});
+							});
+							// determine the max height for each row
+							cellsHeights.forEach(function (row, rowIndex) {
+								row.forEach(function (cellHeight) {
+									var type = typeof tableHeights[rowIndex];
+									if (
+										type === "undefined" ||
+										(cellHeight !== "auto" &&
+											type === "number" &&
+											cellHeight > tableHeights[rowIndex]) ||
+										(cellHeight !== "auto" && tableHeights[rowIndex] === "auto")
+									) {
+										tableHeights[rowIndex] = cellHeight;
+									}
+								});
+							});
+							if (tableWidths.length > 0) ret.table.widths = tableWidths;
+							if (tableHeights.length > 0) ret.table.heights = tableHeights;
+						}
 
-            // check if we have some data-pdfmake to apply
-            if (element.dataset && element.dataset.pdfmake) {
-              dataset = JSON.parse(element.dataset.pdfmake);
-              for (key in dataset) {
-                if (key === "layout") {
-                  ret.layout = dataset[key];
-                } else {
-                  ret.table[key] = dataset[key];
-                }
-              }
-            }
-            break;
-          }
-          case "TH":
-          case "TD":{
-            if (element.getAttribute("rowspan")) ret.rowSpan = element.getAttribute("rowspan")*1;
-            if (element.getAttribute("colspan")) ret.colSpan = element.getAttribute("colspan")*1;
-            // apply all the inhirent classes and styles from the parents, or for the current element
-            ret = applyStyle({ret:ret, parents:parents.concat([element])});
-            break;
-          }
-          case "SVG": {
-            ret = {
-              svg:element.outerHTML.replace(/\n(\s+)?/g, ""),
-              nodeName:'SVG',
-              style:['html-svg']
-            }
-            break;
-          }
-          case "BR": {
-            // for BR we return '\n'
-            ret.text = [{text:'\n'}];
-            break;
-          }
-          case "HR": {
-            // default style for the HR
-            var styleHR = {
-              width: 514,
-              type: "line",
-              margin: [0, 12, 0, 12],
-              thickness: 0.5,
-              color: "#000000",
-              left: 0
-            };
-            // we can override the default HR style with "data-pdfmake"
-            if (element.dataset && element.dataset.pdfmake) {
-              dataset = JSON.parse(element.dataset.pdfmake);
-              for (key in dataset) {
-                styleHR[key] = dataset[key];
-              }
-            }
+						// check if we have some data-pdfmake to apply
+						if (element.dataset && element.dataset.pdfmake) {
+							dataset = JSON.parse(element.dataset.pdfmake);
+							for (key in dataset) {
+								if (key === "layout") {
+									ret.layout = dataset[key];
+								} else {
+									ret.table[key] = dataset[key];
+								}
+							}
+						}
+						break;
+					}
+					case "TH":
+					case "TD": {
+						if (element.getAttribute("rowspan"))
+							ret.rowSpan = element.getAttribute("rowspan") * 1;
+						if (element.getAttribute("colspan"))
+							ret.colSpan = element.getAttribute("colspan") * 1;
+						// apply all the inhirent classes and styles from the parents, or for the current element
+						ret = applyStyle({ ret: ret, parents: parents.concat([element]) });
+						break;
+					}
+					case "SVG": {
+						ret = {
+							svg: element.outerHTML.replace(/\n(\s+)?/g, ""),
+							nodeName: "SVG",
+							style: ["html-svg"],
+						};
+						break;
+					}
+					case "BR": {
+						// for BR we return '\n'
+						ret.text = [{ text: "\n" }];
+						break;
+					}
+					case "HR": {
+						// default style for the HR
+						var styleHR = {
+							width: 514,
+							type: "line",
+							margin: [0, 12, 0, 12],
+							thickness: 0.5,
+							color: "#000000",
+							left: 0,
+						};
+						// we can override the default HR style with "data-pdfmake"
+						if (element.dataset && element.dataset.pdfmake) {
+							dataset = JSON.parse(element.dataset.pdfmake);
+							for (key in dataset) {
+								styleHR[key] = dataset[key];
+							}
+						}
 
-            ret.margin = styleHR.margin;
-            ret.canvas = [
-              {
-                type: styleHR.type,
-                x1: styleHR.left,
-                y1: 0,
-                x2: styleHR.width,
-                y2: 0,
-                lineWidth: styleHR.thickness,
-                lineColor: styleHR.color
-              }
-            ];
-            delete ret.text;
+						ret.margin = styleHR.margin;
+						ret.canvas = [
+							{
+								type: styleHR.type,
+								x1: styleHR.left,
+								y1: 0,
+								x2: styleHR.width,
+								y2: 0,
+								lineWidth: styleHR.thickness,
+								lineColor: styleHR.color,
+							},
+						];
+						delete ret.text;
 
-            break;
-          }
-          case "OL":
-          case "UL": {
-            ret[nodeNameLowerCase] = (ret.stack || ret.text).slice(0);
-            delete ret.stack;
-            delete ret.text;
-            // apply all the inhirent classes and styles from the parents, or for the current element
-            ret = applyStyle({ret:ret, parents:parents.concat([element])});
-            // check if we have `list-style-type` or `list-style`
-            if (ret.listStyle || ret.listStyleType) ret.type = ret.listStyle || ret.listStyleType;
-            break;
-          }
-          case "IMG": {
-            ret.image = element.getAttribute("src");
-            delete ret.stack;
-            delete ret.text;
-            // apply all the inhirent classes and styles from the parents, or for the current element
-            ret = applyStyle({ret:ret, parents:parents.concat([element])});
-            break;
-          }
-          case "A": {
-            ret.link = element.getAttribute("href");
-            break;
-          }
-        }
-        if (Array.isArray(ret.text) && ret.text.length === 1 && ret.text[0].text && !ret.text[0].nodeName) {
-          ret.text = ret.text[0].text;
-        }
+						break;
+					}
+					case "OL":
+					case "UL": {
+						ret[nodeNameLowerCase] = (ret.stack || ret.text).slice(0);
+						delete ret.stack;
+						delete ret.text;
+						// apply all the inhirent classes and styles from the parents, or for the current element
+						ret = applyStyle({ ret: ret, parents: parents.concat([element]) });
+						// check if we have `list-style-type` or `list-style`
+						if (ret.listStyle || ret.listStyleType)
+							ret.type = ret.listStyle || ret.listStyleType;
+						break;
+					}
+					case "IMG": {
+						ret.image = element.getAttribute("src");
+						delete ret.stack;
+						delete ret.text;
+						// apply all the inhirent classes and styles from the parents, or for the current element
+						ret = applyStyle({ ret: ret, parents: parents.concat([element]) });
+						break;
+					}
+					case "A": {
+						ret.link = element.getAttribute("href");
+						break;
+					}
+					case "FONT": {
+						if (element.getAttribute("color")) {
+							ret.color = parseColor(element.getAttribute("color"));
+							ret = applyStyle({
+								ret: ret,
+								parents: parents.concat([element]),
+							});
+						}
+						break;
+					}
+				}
+				if (
+					Array.isArray(ret.text) &&
+					ret.text.length === 1 &&
+					ret.text[0].text &&
+					!ret.text[0].nodeName
+				) {
+					ret.text = ret.text[0].text;
+				}
 
-        // chekck if we have some data-pdfmake to apply
-        if (['HR','TABLE'].indexOf(nodeName) === -1 && element.dataset && element.dataset.pdfmake) {
-          dataset = JSON.parse(element.dataset.pdfmake);
-          for (key in dataset) {
-            ret[key] = dataset[key];
-          }
-        }
+				// chekck if we have some data-pdfmake to apply
+				if (
+					["HR", "TABLE"].indexOf(nodeName) === -1 &&
+					element.dataset &&
+					element.dataset.pdfmake
+				) {
+					dataset = JSON.parse(element.dataset.pdfmake);
+					for (key in dataset) {
+						ret[key] = dataset[key];
+					}
+				}
+				return ret;
+			}
+		}
+	};
 
-        return ret;
-      }
-    }
-  }
+	var searchForStack = function (ret) {
+		if (Array.isArray(ret.text)) {
+			for (var i = 0; i < ret.text.length; i++) {
+				if (
+					ret.text[i].stack ||
+					[
+						"P",
+						"DIV",
+						"TABLE",
+						"SVG",
+						"UL",
+						"OL",
+						"IMG",
+						"H1",
+						"H2",
+						"H3",
+						"H4",
+						"H5",
+						"H6",
+					].indexOf(ret.text[i].nodeName) > -1
+				)
+					return true;
+				if (searchForStack(ret.text[i]) === true) return true;
+			}
+		}
+		return false;
+	};
 
-  var searchForStack = function(ret) {
-    if (Array.isArray(ret.text)) {
-      for (var i=0; i<ret.text.length; i++) {
-        if (ret.text[i].stack || ['P','DIV','TABLE','SVG','UL','OL','IMG','H1','H2','H3','H4','H5','H6'].indexOf(ret.text[i].nodeName) > -1) return true;
-        if (searchForStack(ret.text[i]) === true) return true;
-      }
-    }
-    return false;
-  }
+	/**
+	 * Add empty cells due to rowspan
+	 *
+	 * @param {Object} params
+	 *   @param {Array} rows
+	 *   @param {Object} cell
+	 *   @param {Number} rowIndex Current row index
+	 *   @param {Number} cellIndex Current cell index
+	 */
+	var setRowSpan = function (params) {
+		var cells;
+		if (params.cell.rowSpan) {
+			for (var i = 1; i <= params.cell.rowSpan - 1; i++) {
+				cells =
+					params.rows[params.rowIndex + i].text ||
+					params.rows[params.rowIndex + i].stack;
+				cells.splice(params.cellIndex, 0, { text: "" });
+			}
+		}
+	};
 
-  /**
-   * Add empty cells due to rowspan
-   *
-   * @param {Object} params
-   *   @param {Array} rows
-   *   @param {Object} cell
-   *   @param {Number} rowIndex Current row index
-   *   @param {Number} cellIndex Current cell index
-   */
-  var setRowSpan = function(params) {
-    var cells;
-    if (params.cell.rowSpan) {
-      for (var i=1; i <= params.cell.rowSpan-1; i++) {
-        cells = (params.rows[params.rowIndex+i].text || params.rows[params.rowIndex+i].stack);
-        cells.splice(params.cellIndex, 0, {text:''});
-      }
-    }
-  }
+	/**
+	 * Apply style and classes from all the parents
+	 *
+	 * @param  {Object} params
+	 *   @param {Object} ret The object that will receive the 'style' and other properties
+	 *   @param {Array} parents Array of node elements
+	 * @return {Object} the modified 'ret'
+	 */
+	var applyStyle = function (params) {
+		var cssClass = [];
+		var lastIndex = params.parents.length - 1;
+		params.parents.forEach(function (parent, parentIndex) {
+			// classes
+			var parentNodeName = parent.nodeName.toLowerCase();
+			var htmlClass = "html-" + parentNodeName;
+			if (htmlClass !== "html-body" && cssClass.indexOf(htmlClass) === -1)
+				cssClass.unshift(htmlClass);
+			var parentClass = (parent.getAttribute("class") || "").split(" ");
+			parentClass.forEach(function (p) {
+				if (p) cssClass.push(p);
+			});
+			// styles
+			var style;
+			// not all the CSS properties should be inhirent
+			var ignoreNonDescendentProperties = parentIndex !== lastIndex;
+			// 1) the default styles
+			if (defaultStyles[parentNodeName]) {
+				for (style in defaultStyles[parentNodeName]) {
+					if (defaultStyles[parentNodeName].hasOwnProperty(style)) {
+						if (
+							!ignoreNonDescendentProperties ||
+							(ignoreNonDescendentProperties &&
+								style.indexOf("margin") === -1 &&
+								style.indexOf("border") === -1)
+						) {
+							// 'decoration' can be an array
+							if (style === "decoration") {
+								if (!Array.isArray(params.ret[style])) params.ret[style] = [];
+								params.ret[style].push(defaultStyles[parentNodeName][style]);
+							} else {
+								params.ret[style] = defaultStyles[parentNodeName][style];
+							}
+						}
+					}
+				}
+			}
+			// 2) element's style
+			// we want TD/TH to receive descendent properties from TR
+			if (parentNodeName === "tr") ignoreNonDescendentProperties = false;
+			style = parseStyle(parent, ignoreNonDescendentProperties);
+			style.forEach(function (stl) {
+				// 'decoration' can be an array
+				if (stl.key === "decoration") {
+					if (!Array.isArray(params.ret[stl.key])) params.ret[stl.key] = [];
+					params.ret[stl.key].push(stl.value);
+				} else {
+					params.ret[stl.key] = stl.value;
+				}
+			});
+		});
+		params.ret.style = cssClass;
+		return params.ret;
+	};
 
-  /**
-   * Apply style and classes from all the parents
-   *
-   * @param  {Object} params
-   *   @param {Object} ret The object that will receive the 'style' and other properties
-   *   @param {Array} parents Array of node elements
-   * @return {Object} the modified 'ret'
-   */
-  var applyStyle = function(params) {
-    var cssClass = [];
-    var lastIndex = params.parents.length-1;
-    params.parents.forEach(function(parent, parentIndex) {
-      // classes
-      var parentNodeName = parent.nodeName.toLowerCase();
-      var htmlClass = 'html-' + parentNodeName;
-      if (htmlClass !== 'html-body' && cssClass.indexOf(htmlClass) === -1) cssClass.unshift(htmlClass);
-      var parentClass = (parent.getAttribute("class")||"").split(' ');
-      parentClass.forEach(function(p) {
-        if (p) cssClass.push(p);
-      });
-      // styles
-      var style;
-      // not all the CSS properties should be inhirent
-      var ignoreNonDescendentProperties = (parentIndex!==lastIndex);
-      // 1) the default styles
-      if (defaultStyles[parentNodeName]) {
-        for (style in defaultStyles[parentNodeName]) {
-          if (defaultStyles[parentNodeName].hasOwnProperty(style)) {
-            if (!ignoreNonDescendentProperties ||
-                (ignoreNonDescendentProperties &&
-                  style.indexOf('margin') === -1 &&
-                  style.indexOf('border') === -1
-                )
-               ) {
-              // 'decoration' can be an array
-              if (style === 'decoration') {
-                if (!Array.isArray(params.ret[style])) params.ret[style]=[];
-                params.ret[style].push(defaultStyles[parentNodeName][style]);
-              } else {
-                params.ret[style] = defaultStyles[parentNodeName][style];
-              }
-            }
-          }
-        }
-      }
-      // 2) element's style
-      // we want TD/TH to receive descendent properties from TR
-      if (parentNodeName === 'tr') ignoreNonDescendentProperties=false;
-      style = parseStyle(parent, ignoreNonDescendentProperties);
-      style.forEach(function(stl) {
-        // 'decoration' can be an array
-        if (stl.key === "decoration") {
-          if (!Array.isArray(params.ret[stl.key])) params.ret[stl.key]=[];
-          params.ret[stl.key].push(stl.value);
-        } else {
-          params.ret[stl.key] = stl.value;
-        }
-      });
-    });
-    params.ret.style = cssClass;
-    return params.ret;
-  }
+	/**
+	 * Transform a CSS expression (e.g. 'margin:10px') in the PDFMake version
+	 *
+	 * @param {String} style The CSS expression to transform
+	 * @param {DOMElement} element
+	 * @param {Boolean} ignoreProperties TRUE when we have to ignore some properties, like border, padding, margin
+	 * @returns {Array} array of {key, value}
+	 */
+	var parseStyle = function (element, ignoreProperties) {
+		var style = element.getAttribute("style") || "";
+		style = style.split(";");
+		// check if we have "width" or "height"
+		if (element.getAttribute("width")) {
+			style.unshift("width:" + element.getAttribute("width") + "px");
+		}
+		if (element.getAttribute("height")) {
+			style.unshift("height:" + element.getAttribute("height") + "px");
+		}
+		var styleDefs = style.map(function (style) {
+			return style.toLowerCase().split(":");
+		});
+		var ret = [];
+		var borders = []; // special treatment for borders
+		var nodeName = element.nodeName.toUpperCase();
+		styleDefs.forEach(function (styleDef) {
+			if (styleDef.length === 2) {
+				var key = styleDef[0].trim();
+				var value = styleDef[1].trim();
+				switch (key) {
+					case "margin": {
+						if (ignoreProperties) break;
+						// pdfMake uses a different order than CSS
+						value = value.split(" ");
+						if (value.length === 1)
+							value = [value[0], value[0], value[0], value[0]];
+						else if (value.length === 2) value = [value[1], value[0]];
+						// vertical | horizontal ==> horizontal | vertical
+						else if (value.length === 3)
+							value = [value[1], value[0], value[1], value[2]];
+						// top | horizontal | bottom ==> left | top | right | bottom
+						else if (value.length === 4)
+							value = [value[3], value[0], value[1], value[2]]; // top | right | bottom | left ==> left | top | right | bottom
 
-  /**
-   * Transform a CSS expression (e.g. 'margin:10px') in the PDFMake version
-   *
-   * @param {String} style The CSS expression to transform
-   * @param {DOMElement} element
-   * @param {Boolean} ignoreProperties TRUE when we have to ignore some properties, like border, padding, margin
-   * @returns {Array} array of {key, value}
-   */
-  var parseStyle = function(element, ignoreProperties) {
-    var style = element.getAttribute("style") || "";
-    style = style.split(';');
-    // check if we have "width" or "height"
-    if (element.getAttribute("width")) {
-      style.unshift("width:" + element.getAttribute("width") + "px");
-    }
-    if (element.getAttribute("height")) {
-      style.unshift("height:" + element.getAttribute("height") + "px");
-    }
-    var styleDefs = style.map(function(style) { return style.toLowerCase().split(':') });
-    var ret = [];
-    var borders = []; // special treatment for borders
-    var nodeName = element.nodeName.toUpperCase();
-    styleDefs.forEach(function(styleDef) {
-      if (styleDef.length===2) {
-        var key = styleDef[0].trim();
-        var value = styleDef[1].trim();
-        switch (key) {
-          case "margin": {
-            if (ignoreProperties) break;
-            // pdfMake uses a different order than CSS
-            value = value.split(' ');
-            if (value.length===1) value=[value[0], value[0], value[0], value[0]];
-            else if (value.length===2) value=[value[1], value[0]]; // vertical | horizontal ==> horizontal | vertical
-            else if (value.length===3) value=[value[1], value[0], value[1], value[2]]; // top | horizontal | bottom ==> left | top | right | bottom
-            else if (value.length===4) value=[value[3], value[0], value[1], value[2]]; // top | right | bottom | left ==> left | top | right | bottom
+						// we now need to convert to PT
+						value.forEach(function (val, i) {
+							value[i] = convertToUnit(val);
+						});
+						// ignore if we have a FALSE in the table
+						if (value.indexOf(false) === -1)
+							ret.push({ key: key, value: value });
+						break;
+					}
+					case "text-align": {
+						ret.push({ key: "alignment", value: value });
+						break;
+					}
+					case "font-weight": {
+						if (value === "bold") ret.push({ key: "bold", value: true });
+						break;
+					}
+					case "text-decoration": {
+						ret.push({ key: "decoration", value: toCamelCase(value) });
+						break;
+					}
+					case "font-style": {
+						if (value === "italic") ret.push({ key: "italics", value: true });
+						break;
+					}
+					case "font-family": {
+						ret.push({ key: "font", value: value.replace(/"|^'|'$/g, "") });
+						break;
+					}
+					case "color": {
+						ret.push({ key: "color", value: parseColor(value) });
+						break;
+					}
+					case "background-color": {
+						// if TH/TD and key is 'background', then we use 'fillColor' instead
+						ret.push({
+							key:
+								nodeName === "TD" || nodeName === "TH"
+									? "fillColor"
+									: "background",
+							value: parseColor(value),
+						});
+						break;
+					}
+					default: {
+						// for borders
+						if (
+							key === "border" ||
+							key.indexOf("border-left") === 0 ||
+							key.indexOf("border-top") === 0 ||
+							key.indexOf("border-right") === 0 ||
+							key.indexOf("border-bottom") === 0
+						) {
+							if (!ignoreProperties) borders.push({ key: key, value: value });
+						} else {
+							// ignore some properties
+							if (
+								ignoreProperties &&
+								(key.indexOf("margin-") === 0 ||
+									key === "width" ||
+									key === "height")
+							)
+								break;
+							// padding is not supported by PDFMake
+							if (key.indexOf("padding") === 0) break;
+							if (key.indexOf("-") > -1) key = toCamelCase(key);
+							if (value) {
+								// convert value to a 'pt' when possible
+								var parsedValue = convertToUnit(value);
+								ret.push({
+									key: key,
+									value: parsedValue === false ? value : parsedValue,
+								});
+							}
+						}
+					}
+				}
+			}
+		});
+		// for borders
+		if (borders.length > 0) {
+			// we have to merge together the borders in two properties
+			var border = []; // array of boolean
+			var borderColor = []; // array of colors
+			borders.forEach(function (b) {
+				// we have 3 properties: width style color
+				var properties = b.value.split(" ");
+				var width = properties[0]
+					.replace(/(\d+)(\.\d+)?([^\d]+)/g, "$1$2 ")
+					.trim();
+				var index = -1,
+					i;
+				if (b.key.indexOf("-left") > -1) index = 0;
+				else if (b.key.indexOf("-top") > -1) index = 1;
+				else if (b.key.indexOf("-right") > -1) index = 2;
+				else if (b.key.indexOf("-bottom") > -1) index = 3;
+				// for the width
+				if (index > -1) {
+					border[index] = width > 0;
+				} else {
+					for (i = 0; i < 4; i++) border[i] = width > 0;
+				}
+				// for the color
+				if (properties.length > 2) {
+					var color = properties.slice(2).join(" ");
+					if (index > -1) {
+						borderColor[index] = parseColor(color);
+					} else {
+						for (i = 0; i < 4; i++) borderColor[i] = parseColor(color);
+					}
+				}
+			});
+			// fill the gaps
+			for (var i = 0; i < 4; i++) {
+				if (border.length > 0 && typeof border[i] === "undefined")
+					border[i] = true;
+				if (borderColor.length > 0 && typeof borderColor[i] === "undefined")
+					borderColor[i] = "#000000";
+			}
+			if (border.length > 0) ret.push({ key: "border", value: border });
+			if (borderColor.length > 0)
+				ret.push({ key: "borderColor", value: borderColor });
+		}
+		return ret;
+	};
 
-            // we now need to convert to PT
-            value.forEach(function(val, i) {
-              value[i] = convertToUnit(val);
-            });
-            // ignore if we have a FALSE in the table
-            if (value.indexOf(false) === -1) ret.push({key:key, value:value});
-            break;
-          }
-          case "text-align": {
-            ret.push({key:"alignment", value:value});
-            break;
-          }
-          case "font-weight": {
-            if (value === "bold") ret.push({key:"bold", value:true});
-            break;
-          }
-          case "text-decoration": {
-            ret.push({key:"decoration", value:toCamelCase(value)})
-            break;
-          }
-          case "font-style": {
-            if (value==="italic") ret.push({key:"italics", value:true});
-            break;
-          }
-          case "font-family": {
-            ret.push({key:"font", value:value.replace(/"|^'|'$/g,"")});
-            break;
-          }
-          case "color": {
-            ret.push({key:"color", value:parseColor(value)})
-            break;
-          }
-          case "background-color": {
-            // if TH/TD and key is 'background', then we use 'fillColor' instead
-            ret.push({key:(nodeName === 'TD' || nodeName === 'TH' ? "fillColor" : "background"), value:parseColor(value)})
-            break;
-          }
-          default: {
-            // for borders
-            if (key === 'border' || key.indexOf('border-left') === 0 || key.indexOf('border-top') === 0 || key.indexOf('border-right') === 0 || key.indexOf('border-bottom') === 0) {
-              if (!ignoreProperties) borders.push({key:key, value:value});
-            } else {
-              // ignore some properties
-              if (ignoreProperties && (key.indexOf("margin-") === 0 || key === 'width' || key === 'height')) break;
-              // padding is not supported by PDFMake
-              if (key.indexOf("padding") === 0) break;
-              if (key.indexOf("-") > -1) key=toCamelCase(key);
-              if (value) {
-                // convert value to a 'pt' when possible
-                var parsedValue = convertToUnit(value);
-                ret.push({key:key, value:(parsedValue === false ? value : parsedValue)});
-              }
-            }
-          }
-        }
-      }
-    });
-    // for borders
-    if (borders.length > 0) {
-      // we have to merge together the borders in two properties
-      var border = []; // array of boolean
-      var borderColor = []; // array of colors
-      borders.forEach(function(b) {
-        // we have 3 properties: width style color
-        var properties = b.value.split(' ');
-        var width = properties[0].replace(/(\d+)(\.\d+)?([^\d]+)/g,"$1$2 ").trim();
-        var index = -1, i;
-        if (b.key.indexOf('-left') > -1) index=0;
-        else if (b.key.indexOf('-top') > -1) index=1;
-        else if (b.key.indexOf('-right') > -1) index=2;
-        else if (b.key.indexOf('-bottom') > -1) index=3;
-        // for the width
-        if (index > -1) {
-          border[index] = (width > 0);
-        } else {
-          for (i=0; i<4; i++) border[i] = (width > 0);
-        }
-        // for the color
-        if (properties.length > 2) {
-          var color = properties.slice(2).join(' ');
-          if (index > -1) {
-            borderColor[index] = parseColor(color);
-          } else {
-            for (i=0; i<4; i++) borderColor[i] = parseColor(color);
-          }
-        }
-      });
-      // fill the gaps
-      for (var i=0; i<4; i++) {
-        if (border.length > 0 && typeof border[i] === "undefined") border[i]=true;
-        if (borderColor.length > 0 && typeof borderColor[i] === "undefined") borderColor[i]='#000000';
-      }
-      if (border.length > 0) ret.push({key:'border', value:border});
-      if (borderColor.length > 0) ret.push({key:'borderColor', value:borderColor});
-    }
-    return ret;
-  }
+	var toCamelCase = function (str) {
+		return str.replace(/-([a-z])/g, function (g) {
+			return g[1].toUpperCase();
+		});
+	};
 
-  var toCamelCase = function(str) {
-    return str.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase() });
-  }
+	/**
+	 * Returns the color in a hex format (e.g. #12ff00).
+	 * Also tries to convert RGB colors into hex values
+	 *
+	 * @param color color as string representation
+	 * @returns color as hex values for pdfmake
+	 */
+	var parseColor = function (color) {
+		var haxRegex = new RegExp("^#([0-9a-f]{3}|[0-9a-f]{6})$");
 
-  /**
-   * Returns the color in a hex format (e.g. #12ff00).
-   * Also tries to convert RGB colors into hex values
-   *
-   * @param color color as string representation
-   * @returns color as hex values for pdfmake
-   */
-  var parseColor = function(color) {
-    var haxRegex = new RegExp('^#([0-9a-f]{3}|[0-9a-f]{6})$');
+		// e.g. `#fff` or `#ff0048`
+		var rgbRegex = new RegExp("^rgb\\((\\d+),\\s*(\\d+),\\s*(\\d+)\\)$");
 
-    // e.g. `#fff` or `#ff0048`
-    var rgbRegex = new RegExp('^rgb\\((\\d+),\\s*(\\d+),\\s*(\\d+)\\)$');
+		// e.g. rgb(0,255,34) or rgb(22, 0, 0)
+		var nameRegex = new RegExp("^[a-z]+$");
 
-    // e.g. rgb(0,255,34) or rgb(22, 0, 0)
-    var nameRegex = new RegExp('^[a-z]+$');
+		if (haxRegex.test(color)) {
+			return color;
+		} else if (rgbRegex.test(color)) {
+			var decimalColors = rgbRegex.exec(color).slice(1);
+			for (var i = 0; i < 3; i++) {
+				var decimalValue = +decimalColors[i];
+				if (decimalValue > 255) {
+					decimalValue = 255;
+				}
+				var hexString = "0" + decimalValue.toString(16);
+				hexString = hexString.slice(-2);
+				decimalColors[i] = hexString;
+			}
+			return "#" + decimalColors.join("");
+		} else if (nameRegex.test(color)) {
+			return color;
+		} else {
+			console.error('Could not parse color "' + color + '"');
+			return color;
+		}
+	};
 
-    if (haxRegex.test(color)) {
-      return color;
-    } else if (rgbRegex.test(color)) {
-      var decimalColors = rgbRegex.exec(color).slice(1);
-      for (var i = 0; i < 3; i++) {
-        var decimalValue = +decimalColors[i];
-        if (decimalValue > 255) {
-          decimalValue = 255;
-        }
-        var hexString = '0' + decimalValue.toString(16);
-        hexString = hexString.slice(-2);
-        decimalColors[i] = hexString;
-      }
-      return '#' + decimalColors.join('');
-    } else if (nameRegex.test(color)) {
-      return color;
-    } else {
-      console.error('Could not parse color "' + color + '"');
-      return color;
-    }
-  }
+	/**
+	 * Convert 'px'/'rem' to 'pt', and return false for the other ones. If it's only a number, it will just return it
+	 *
+	 * @param  {String} val The value with units (e.g. 12px)
+	 * @return {Number|Boolean} Return the pt value, or false
+	 */
+	var convertToUnit = function (val) {
+		// if it's just a number, then return it
+		if (!isNaN(parseFloat(val)) && isFinite(val)) return val * 1;
+		var mtch = (val + "").trim().match(/^(\d+(\.\d+)?)(pt|px|rem)$/);
+		// if we don't have a number with supported units, then return false
+		if (!mtch) return false;
+		val = mtch[1];
+		switch (mtch[3]) {
+			case "px": {
+				val = Math.round(val * 0.75292857248934); // 1px => 0.75292857248934pt
+				break;
+			}
+			case "rem": {
+				val *= 12; // default font-size is 12pt
+				break;
+			}
+		}
+		return val * 1;
+	};
 
-  /**
-   * Convert 'px'/'rem' to 'pt', and return false for the other ones. If it's only a number, it will just return it
-   *
-   * @param  {String} val The value with units (e.g. 12px)
-   * @return {Number|Boolean} Return the pt value, or false
-   */
-  var convertToUnit = function(val) {
-    // if it's just a number, then return it
-    if (!isNaN(parseFloat(val)) && isFinite(val)) return val*1;
-    var mtch = (val+"").trim().match(/^(\d+(\.\d+)?)(pt|px|rem)$/);
-    // if we don't have a number with supported units, then return false
-    if (!mtch) return false;
-    val = mtch[1];
-    switch(mtch[3]) {
-      case 'px':{
-        val = Math.round(val * 0.75292857248934); // 1px => 0.75292857248934pt
-        break;
-      }
-      case 'rem':{
-        val *= 12; // default font-size is 12pt
-        break;
-      }
-    }
-    return val*1;
-  }
-
-  return convertHtml(htmlText)
-}
+	return convertHtml(htmlText);
+};

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,220 +1,258 @@
-var htmlToPdfMake = require('../index.js');
+var htmlToPdfMake = require("../index.js");
 var test = require("simple-test-framework");
 var jsdom = require("jsdom");
 var { JSDOM } = jsdom;
 var { window } = new JSDOM("");
 var debug = false;
 
-test("b",function(t) {
-  var ret = htmlToPdfMake("<b>bold word</b>", {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.text === "bold word" &&
-    ret.bold === true &&
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-b',
-  "<b>");
+test("b", function (t) {
+	var ret = htmlToPdfMake("<b>bold word</b>", { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.text === "bold word" &&
+			ret.bold === true &&
+			Array.isArray(ret.style) &&
+			ret.style[0] === "html-b",
+		"<b>"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("strong",function(t) {
-  var ret = htmlToPdfMake("<strong>bold word</strong>", {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.text === "bold word" &&
-    ret.bold === true &&
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-strong',
-  "<strong>");
+test("strong", function (t) {
+	var ret = htmlToPdfMake("<strong>bold word</strong>", { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.text === "bold word" &&
+			ret.bold === true &&
+			Array.isArray(ret.style) &&
+			ret.style[0] === "html-strong",
+		"<strong>"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("u",function(t) {
-  var ret = htmlToPdfMake("<u>underline word</u>", {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.text === "underline word" &&
-    Array.isArray(ret.decoration) && ret.decoration.length === 1 && ret.decoration[0] &&
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-u',
-  "<u>");
+test("u", function (t) {
+	var ret = htmlToPdfMake("<u>underline word</u>", { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.text === "underline word" &&
+			Array.isArray(ret.decoration) &&
+			ret.decoration.length === 1 &&
+			ret.decoration[0] &&
+			Array.isArray(ret.style) &&
+			ret.style[0] === "html-u",
+		"<u>"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("em",function(t) {
-  var ret = htmlToPdfMake("<em>italic word</em>", {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.text === "italic word" &&
-    ret.italics === true &&
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-em',
-  "<em>");
+test("em", function (t) {
+	var ret = htmlToPdfMake("<em>italic word</em>", { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.text === "italic word" &&
+			ret.italics === true &&
+			Array.isArray(ret.style) &&
+			ret.style[0] === "html-em",
+		"<em>"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("i",function(t) {
-  var ret = htmlToPdfMake("<i>italic word</i>", {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.text === "italic word" &&
-    ret.italics === true &&
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-i',
-  "<i>");
+test("i", function (t) {
+	var ret = htmlToPdfMake("<i>italic word</i>", { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.text === "italic word" &&
+			ret.italics === true &&
+			Array.isArray(ret.style) &&
+			ret.style[0] === "html-i",
+		"<i>"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("h1",function(t) {
-  var ret = htmlToPdfMake("<h1>level 1</h1>", {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret), "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.text === "level 1" &&
-    ret.fontSize === 24 &&
-    ret.bold === true &&
-    ret.marginBottom === 5 &&
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-h1',
-  "<h1>");
+test("h1", function (t) {
+	var ret = htmlToPdfMake("<h1>level 1</h1>", { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret), "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.text === "level 1" &&
+			ret.fontSize === 24 &&
+			ret.bold === true &&
+			ret.marginBottom === 5 &&
+			Array.isArray(ret.style) &&
+			ret.style[0] === "html-h1",
+		"<h1>"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("h2",function(t) {
-  var ret = htmlToPdfMake("<h2>level 2</h2>", {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret), "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.text === "level 2" &&
-    ret.fontSize === 22 &&
-    ret.bold === true &&
-    ret.marginBottom === 5 &&
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-h2',
-  "<h2>");
+test("h2", function (t) {
+	var ret = htmlToPdfMake("<h2>level 2</h2>", { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret), "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.text === "level 2" &&
+			ret.fontSize === 22 &&
+			ret.bold === true &&
+			ret.marginBottom === 5 &&
+			Array.isArray(ret.style) &&
+			ret.style[0] === "html-h2",
+		"<h2>"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("h3",function(t) {
-  var ret = htmlToPdfMake("<h3>level 3</h3>", {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret), "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.text === "level 3" &&
-    ret.fontSize === 20 &&
-    ret.bold === true &&
-    ret.marginBottom === 5 &&
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-h3',
-  "<h3>");
+test("h3", function (t) {
+	var ret = htmlToPdfMake("<h3>level 3</h3>", { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret), "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.text === "level 3" &&
+			ret.fontSize === 20 &&
+			ret.bold === true &&
+			ret.marginBottom === 5 &&
+			Array.isArray(ret.style) &&
+			ret.style[0] === "html-h3",
+		"<h3>"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("h4",function(t) {
-  var ret = htmlToPdfMake("<h4>level 4</h4>", {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret), "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.text === "level 4" &&
-    ret.fontSize === 18 &&
-    ret.bold === true &&
-    ret.marginBottom === 5 &&
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-h4',
-  "<h4>");
+test("h4", function (t) {
+	var ret = htmlToPdfMake("<h4>level 4</h4>", { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret), "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.text === "level 4" &&
+			ret.fontSize === 18 &&
+			ret.bold === true &&
+			ret.marginBottom === 5 &&
+			Array.isArray(ret.style) &&
+			ret.style[0] === "html-h4",
+		"<h4>"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("h5",function(t) {
-  var ret = htmlToPdfMake("<h5>level 5</h5>", {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret), "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.text === "level 5" &&
-    ret.fontSize === 16 &&
-    ret.bold === true &&
-    ret.marginBottom === 5 &&
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-h5',
-  "<h5>");
+test("h5", function (t) {
+	var ret = htmlToPdfMake("<h5>level 5</h5>", { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret), "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.text === "level 5" &&
+			ret.fontSize === 16 &&
+			ret.bold === true &&
+			ret.marginBottom === 5 &&
+			Array.isArray(ret.style) &&
+			ret.style[0] === "html-h5",
+		"<h5>"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("h6",function(t) {
-  var ret = htmlToPdfMake("<h6>level 6</h6>", {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret), "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.text === "level 6" &&
-    ret.fontSize === 14 &&
-    ret.bold === true &&
-    ret.marginBottom === 5 &&
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-h6',
-  "<h6>");
+test("h6", function (t) {
+	var ret = htmlToPdfMake("<h6>level 6</h6>", { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret), "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.text === "level 6" &&
+			ret.fontSize === 14 &&
+			ret.bold === true &&
+			ret.marginBottom === 5 &&
+			Array.isArray(ret.style) &&
+			ret.style[0] === "html-h6",
+		"<h6>"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("a",function(t) {
-  var ret = htmlToPdfMake('<a href="https://www.somewhere.com">link</a>', {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(ret.text === "link", "text");
-  t.check(ret.color === "blue", "color");
-  t.check(Array.isArray(ret.decoration) && ret.decoration.length === 1 && ret.decoration[0] === "underline", "decoration");
-  t.check(ret.link === "https://www.somewhere.com", "href");
-  t.check(Array.isArray(ret.style), "style is array");
-  t.check(ret.style[0] === 'html-a', "class");
+test("font", function (t) {
+	var ret = htmlToPdfMake(
+		"<font color='#ff0033' size='4'>font element</font>",
+		{
+			window: window,
+			fontSizes: [10, 14, 16, 444, 20, 24, 28],
+		}
+	);
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(ret.color === "#ff0033" && ret.fontSize === 444, "<font>");
+	t.finish();
+});
 
-  t.finish();
-})
+test("a", function (t) {
+	var ret = htmlToPdfMake('<a href="https://www.somewhere.com">link</a>', {
+		window: window,
+	});
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(ret.text === "link", "text");
+	t.check(ret.color === "blue", "color");
+	t.check(
+		Array.isArray(ret.decoration) &&
+			ret.decoration.length === 1 &&
+			ret.decoration[0] === "underline",
+		"decoration"
+	);
+	t.check(ret.link === "https://www.somewhere.com", "href");
+	t.check(Array.isArray(ret.style), "style is array");
+	t.check(ret.style[0] === "html-a", "class");
 
-test("strike",function(t) {
-  var ret = htmlToPdfMake("<strike>strike</strike>", {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.text === "strike" &&
-    Array.isArray(ret.decoration) && ret.decoration.length === 1 && ret.decoration[0] === "lineThrough" &&
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-strike',
-  "<strike>");
+	t.finish();
+});
 
-  t.finish();
-})
+test("strike", function (t) {
+	var ret = htmlToPdfMake("<strike>strike</strike>", { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.text === "strike" &&
+			Array.isArray(ret.decoration) &&
+			ret.decoration.length === 1 &&
+			ret.decoration[0] === "lineThrough" &&
+			Array.isArray(ret.style) &&
+			ret.style[0] === "html-strike",
+		"<strike>"
+	);
+
+	t.finish();
+});
 
 // [{"table":{"body":[[{"text":"Header Column A","bold":true,"fillColor":"#EEEEEE","style":["html-th"]},{"text":"Header Column B","bold":true,"fillColor":"#EEEEEE","style":["html-th"]}],[{"text":"Value Cell A2","style":["html-td"]},{"text":"Value Cell B2","style":["html-td"]}],[{"text":"Value Cell A3","style":["html-td"]},{"text":"Value Cell B3","style":["html-td"]}]]},"style":"html-table","marginBottom":5}]
-test("table",function(t) {
-  var html = `<table>
+test("table", function (t) {
+	var html = `<table>
     <thead>
       <tr>
         <th>Header Column A</th>
@@ -232,81 +270,84 @@ test("table",function(t) {
       </tr>
     </tbody>
   </table>`;
-  var ret = htmlToPdfMake(html, {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.table &&
-    Array.isArray(ret.table.body) &&
-    ret.table.body.length === 3 &&
-    ret.table.body[0][0].text === "Header Column A" &&
-    ret.table.body[0][0].style[0] === 'html-th' &&
-    ret.table.body[0][0].style[1] === 'html-tr' &&
-    ret.table.body[1][1].text === "Value Cell B2" &&
-    ret.table.body[1][1].style[0] === 'html-td' &&
-    ret.table.body[1][1].style[1] === 'html-tr' &&
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-table',
-  "<table>");
+	var ret = htmlToPdfMake(html, { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.table &&
+			Array.isArray(ret.table.body) &&
+			ret.table.body.length === 3 &&
+			ret.table.body[0][0].text === "Header Column A" &&
+			ret.table.body[0][0].style[0] === "html-th" &&
+			ret.table.body[0][0].style[1] === "html-tr" &&
+			ret.table.body[1][1].text === "Value Cell B2" &&
+			ret.table.body[1][1].style[0] === "html-td" &&
+			ret.table.body[1][1].style[1] === "html-tr" &&
+			Array.isArray(ret.style) &&
+			ret.style[0] === "html-table",
+		"<table>"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
 // { table:  { body: [ [ { text: 'Cell1', style: [ 'html-td', 'html-tr' ] } ] ] },  style: [ 'html-table' ],  marginBottom: 5 }
-test("table (one row/one column)",function(t) {
-  var html = `<table>
+test("table (one row/one column)", function (t) {
+	var html = `<table>
       <tr>
         <td>Cell1</td>
       </tr>
   </table>`;
-  var ret = htmlToPdfMake(html, {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.table &&
-    Array.isArray(ret.table.body) &&
-    ret.table.body.length === 1 &&
-    ret.table.body[0][0].text === "Cell1" &&
-    ret.table.body[0][0].style[0] === 'html-td' &&
-    ret.table.body[0][0].style[1] === 'html-tr' &&
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-table',
-  "table (one row/one column)");
+	var ret = htmlToPdfMake(html, { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.table &&
+			Array.isArray(ret.table.body) &&
+			ret.table.body.length === 1 &&
+			ret.table.body[0][0].text === "Cell1" &&
+			ret.table.body[0][0].style[0] === "html-td" &&
+			ret.table.body[0][0].style[1] === "html-tr" &&
+			Array.isArray(ret.style) &&
+			ret.style[0] === "html-table",
+		"table (one row/one column)"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("table (one row/two columns)",function(t) {
-  var html = `<table>
+test("table (one row/two columns)", function (t) {
+	var html = `<table>
       <tr>
         <td>Cell1</td><td>Cell2</td>
       </tr>
   </table>`;
-  var ret = htmlToPdfMake(html, {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.table &&
-    Array.isArray(ret.table.body) &&
-    ret.table.body.length === 1 &&
-    ret.table.body[0][0].text === "Cell1" &&
-    ret.table.body[0][0].style[0] === 'html-td' &&
-    ret.table.body[0][0].style[1] === 'html-tr' &&
-    ret.table.body[0][1].text === "Cell2" &&
-    ret.table.body[0][1].style[0] === 'html-td' &&
-    ret.table.body[0][1].style[1] === 'html-tr' &&
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-table',
-  "table (one row/two columns)");
+	var ret = htmlToPdfMake(html, { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.table &&
+			Array.isArray(ret.table.body) &&
+			ret.table.body.length === 1 &&
+			ret.table.body[0][0].text === "Cell1" &&
+			ret.table.body[0][0].style[0] === "html-td" &&
+			ret.table.body[0][0].style[1] === "html-tr" &&
+			ret.table.body[0][1].text === "Cell2" &&
+			ret.table.body[0][1].style[0] === "html-td" &&
+			ret.table.body[0][1].style[1] === "html-tr" &&
+			Array.isArray(ret.style) &&
+			ret.style[0] === "html-table",
+		"table (one row/two columns)"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("table (two rows/one column)",function(t) {
-  var html = `<table>
+test("table (two rows/one column)", function (t) {
+	var html = `<table>
       <tr>
         <td>Cell1</td>
       </tr>
@@ -314,29 +355,30 @@ test("table (two rows/one column)",function(t) {
         <td>Cell2</td>
       </tr>
   </table>`;
-  var ret = htmlToPdfMake(html, {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.table &&
-    Array.isArray(ret.table.body) &&
-    ret.table.body.length === 2 &&
-    ret.table.body[0][0].text === "Cell1" &&
-    ret.table.body[0][0].style[0] === 'html-td' &&
-    ret.table.body[0][0].style[1] === 'html-tr' &&
-    ret.table.body[1][0].text === "Cell2" &&
-    ret.table.body[1][0].style[0] === 'html-td' &&
-    ret.table.body[1][0].style[1] === 'html-tr' &&
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-table',
-  "table (two rows/one column)");
+	var ret = htmlToPdfMake(html, { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.table &&
+			Array.isArray(ret.table.body) &&
+			ret.table.body.length === 2 &&
+			ret.table.body[0][0].text === "Cell1" &&
+			ret.table.body[0][0].style[0] === "html-td" &&
+			ret.table.body[0][0].style[1] === "html-tr" &&
+			ret.table.body[1][0].text === "Cell2" &&
+			ret.table.body[1][0].style[0] === "html-td" &&
+			ret.table.body[1][0].style[1] === "html-tr" &&
+			Array.isArray(ret.style) &&
+			ret.style[0] === "html-table",
+		"table (two rows/one column)"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("table (rowspan/colspan)", function(t) {
-  var html = `<table>
+test("table (rowspan/colspan)", function (t) {
+	var html = `<table>
     <tr>
       <th>Col A</th>
       <th>Col B</th>
@@ -372,52 +414,65 @@ test("table (rowspan/colspan)", function(t) {
       <td>Cell D5</td>
     </tr>
   </table>`;
-  var ret = htmlToPdfMake(html, {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
+	var ret = htmlToPdfMake(html, { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
 
-  t.check(
-    ret.table &&
-    Array.isArray(ret.table.body) &&
-    ret.table.body.length === 6, "base");
-  t.check(
-    ret.table.body[1][0].text === "Cell A1" &&
-    ret.table.body[1][0].style[0] === 'html-td' &&
-    ret.table.body[1][0].style[1] === 'html-tr', "row 1");
-  t.check(
-    ret.table.body[1][1].text === "Cell B1 & B2" &&
-    ret.table.body[1][2].text === "Cell C1" &&
-    ret.table.body[1][3].text === "Cell D1 & D2", "row 2");
-  t.check(
-    ret.table.body[2][0].text === "Cell A2" &&
-    ret.table.body[2][1].text === "" &&
-    ret.table.body[2][2].text === "Cell C2" &&
-    ret.table.body[2][3].text === "", "row 3");
-  t.check(
-    ret.table.body[3][0].text === "Cell A3" &&
-    ret.table.body[3][1].text === "Cell B3 & C3" &&
-    ret.table.body[3][2].text === "" &&
-    ret.table.body[3][3].text === "Cell D3", "row 4");
-  t.check(
-    ret.table.body[4][0].text === "Cell A4 & A5 & B4 & B5 & C4 & C5" &&
-    ret.table.body[4][1].text === "" &&
-    ret.table.body[4][2].text === "" &&
-    ret.table.body[4][3].text === "Cell D4", "row 5");
-  t.check(
-    ret.table.body[5][0].text === "" &&
-    ret.table.body[5][1].text === "" &&
-    ret.table.body[5][2].text === "" &&
-    ret.table.body[5][3].text === "Cell D5", "row 6");
-  t.check(
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-table', "table style");
+	t.check(
+		ret.table && Array.isArray(ret.table.body) && ret.table.body.length === 6,
+		"base"
+	);
+	t.check(
+		ret.table.body[1][0].text === "Cell A1" &&
+			ret.table.body[1][0].style[0] === "html-td" &&
+			ret.table.body[1][0].style[1] === "html-tr",
+		"row 1"
+	);
+	t.check(
+		ret.table.body[1][1].text === "Cell B1 & B2" &&
+			ret.table.body[1][2].text === "Cell C1" &&
+			ret.table.body[1][3].text === "Cell D1 & D2",
+		"row 2"
+	);
+	t.check(
+		ret.table.body[2][0].text === "Cell A2" &&
+			ret.table.body[2][1].text === "" &&
+			ret.table.body[2][2].text === "Cell C2" &&
+			ret.table.body[2][3].text === "",
+		"row 3"
+	);
+	t.check(
+		ret.table.body[3][0].text === "Cell A3" &&
+			ret.table.body[3][1].text === "Cell B3 & C3" &&
+			ret.table.body[3][2].text === "" &&
+			ret.table.body[3][3].text === "Cell D3",
+		"row 4"
+	);
+	t.check(
+		ret.table.body[4][0].text === "Cell A4 & A5 & B4 & B5 & C4 & C5" &&
+			ret.table.body[4][1].text === "" &&
+			ret.table.body[4][2].text === "" &&
+			ret.table.body[4][3].text === "Cell D4",
+		"row 5"
+	);
+	t.check(
+		ret.table.body[5][0].text === "" &&
+			ret.table.body[5][1].text === "" &&
+			ret.table.body[5][2].text === "" &&
+			ret.table.body[5][3].text === "Cell D5",
+		"row 6"
+	);
+	t.check(
+		Array.isArray(ret.style) && ret.style[0] === "html-table",
+		"table style"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("table (rowspan/colspan) with thead tbody", function(t) {
-  var html = `<table>
+test("table (rowspan/colspan) with thead tbody", function (t) {
+	var html = `<table>
     <thead>
         <tr>
           <th>Col A</th>
@@ -457,52 +512,65 @@ test("table (rowspan/colspan) with thead tbody", function(t) {
         </tr>
     </tbody>
   </table>`;
-  var ret = htmlToPdfMake(html, {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
+	var ret = htmlToPdfMake(html, { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
 
-  t.check(
-    ret.table &&
-    Array.isArray(ret.table.body) &&
-    ret.table.body.length === 6, "base");
-  t.check(
-    ret.table.body[1][0].text === "Cell A1" &&
-    ret.table.body[1][0].style[0] === 'html-td' &&
-    ret.table.body[1][0].style[1] === 'html-tr', "row 1");
-  t.check(
-    ret.table.body[1][1].text === "Cell B1 & B2" &&
-    ret.table.body[1][2].text === "Cell C1" &&
-    ret.table.body[1][3].text === "Cell D1 & D2", "row 2");
-  t.check(
-    ret.table.body[2][0].text === "Cell A2" &&
-    ret.table.body[2][1].text === "" &&
-    ret.table.body[2][2].text === "Cell C2" &&
-    ret.table.body[2][3].text === "", "row 3");
-  t.check(
-    ret.table.body[3][0].text === "Cell A3" &&
-    ret.table.body[3][1].text === "Cell B3 & C3" &&
-    ret.table.body[3][2].text === "" &&
-    ret.table.body[3][3].text === "Cell D3", "row 4");
-  t.check(
-    ret.table.body[4][0].text === "Cell A4 & A5 & B4 & B5 & C4 & C5" &&
-    ret.table.body[4][1].text === "" &&
-    ret.table.body[4][2].text === "" &&
-    ret.table.body[4][3].text === "Cell D4", "row 5");
-  t.check(
-    ret.table.body[5][0].text === "" &&
-    ret.table.body[5][1].text === "" &&
-    ret.table.body[5][2].text === "" &&
-    ret.table.body[5][3].text === "Cell D5", "row 6");
-  t.check(
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-table', "table style");
+	t.check(
+		ret.table && Array.isArray(ret.table.body) && ret.table.body.length === 6,
+		"base"
+	);
+	t.check(
+		ret.table.body[1][0].text === "Cell A1" &&
+			ret.table.body[1][0].style[0] === "html-td" &&
+			ret.table.body[1][0].style[1] === "html-tr",
+		"row 1"
+	);
+	t.check(
+		ret.table.body[1][1].text === "Cell B1 & B2" &&
+			ret.table.body[1][2].text === "Cell C1" &&
+			ret.table.body[1][3].text === "Cell D1 & D2",
+		"row 2"
+	);
+	t.check(
+		ret.table.body[2][0].text === "Cell A2" &&
+			ret.table.body[2][1].text === "" &&
+			ret.table.body[2][2].text === "Cell C2" &&
+			ret.table.body[2][3].text === "",
+		"row 3"
+	);
+	t.check(
+		ret.table.body[3][0].text === "Cell A3" &&
+			ret.table.body[3][1].text === "Cell B3 & C3" &&
+			ret.table.body[3][2].text === "" &&
+			ret.table.body[3][3].text === "Cell D3",
+		"row 4"
+	);
+	t.check(
+		ret.table.body[4][0].text === "Cell A4 & A5 & B4 & B5 & C4 & C5" &&
+			ret.table.body[4][1].text === "" &&
+			ret.table.body[4][2].text === "" &&
+			ret.table.body[4][3].text === "Cell D4",
+		"row 5"
+	);
+	t.check(
+		ret.table.body[5][0].text === "" &&
+			ret.table.body[5][1].text === "" &&
+			ret.table.body[5][2].text === "" &&
+			ret.table.body[5][3].text === "Cell D5",
+		"row 6"
+	);
+	t.check(
+		Array.isArray(ret.style) && ret.style[0] === "html-table",
+		"table style"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("table (colspan + empty cell)", function(t) {
-  var html = `<table>
+test("table (colspan + empty cell)", function (t) {
+	var html = `<table>
     <thead>
       <tr>
         <th colspan="2">header</th>
@@ -519,111 +587,124 @@ test("table (colspan + empty cell)", function(t) {
       </tr>
     </tbody>
   </table>`;
-  var ret = htmlToPdfMake(html, {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
+	var ret = htmlToPdfMake(html, { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
 
-  t.check(
-    ret.table &&
-    Array.isArray(ret.table.body) &&
-    ret.table.body.length === 3, "base");
-  t.check(
-    ret.table.body[0].length === 2 &&
-    ret.table.body[0][0].text === "header" &&
-    ret.table.body[0][0].style[0] === 'html-th' &&
-    ret.table.body[0][0].style[1] === 'html-tr', "row 1");
-  t.check(
-    ret.table.body[1].length === 2 &&
-    ret.table.body[1][0].text === "Cell A1" &&
-    ret.table.body[1][1].text === "Cell A2", "row 2");
-  t.check(
-    ret.table.body[2].length === 2 &&
-    ret.table.body[2][0].text === "Cell B1" &&
-    ret.table.body[2][1].text === "", "row 3");
-  t.check(
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-table', "table style");
+	t.check(
+		ret.table && Array.isArray(ret.table.body) && ret.table.body.length === 3,
+		"base"
+	);
+	t.check(
+		ret.table.body[0].length === 2 &&
+			ret.table.body[0][0].text === "header" &&
+			ret.table.body[0][0].style[0] === "html-th" &&
+			ret.table.body[0][0].style[1] === "html-tr",
+		"row 1"
+	);
+	t.check(
+		ret.table.body[1].length === 2 &&
+			ret.table.body[1][0].text === "Cell A1" &&
+			ret.table.body[1][1].text === "Cell A2",
+		"row 2"
+	);
+	t.check(
+		ret.table.body[2].length === 2 &&
+			ret.table.body[2][0].text === "Cell B1" &&
+			ret.table.body[2][1].text === "",
+		"row 3"
+	);
+	t.check(
+		Array.isArray(ret.style) && ret.style[0] === "html-table",
+		"table style"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("img",function(t) {
-  var ret = htmlToPdfMake('<img width="10" style="height:10px" src="data:image/jpeg;base64,...encodedContent...">', {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.image === "data:image/jpeg;base64,...encodedContent..." &&
-    ret.width === 8 && ret.height === 8 &&
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-img',
-  "<img>");
+test("img", function (t) {
+	var ret = htmlToPdfMake(
+		'<img width="10" style="height:10px" src="data:image/jpeg;base64,...encodedContent...">',
+		{ window: window }
+	);
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.image === "data:image/jpeg;base64,...encodedContent..." &&
+			ret.width === 8 &&
+			ret.height === 8 &&
+			Array.isArray(ret.style) &&
+			ret.style[0] === "html-img",
+		"<img>"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("svg",function(t) {
-  var ret = htmlToPdfMake(`
+test("svg", function (t) {
+	var ret = htmlToPdfMake(
+		`
     <svg version="1.1" baseProfile="full" width="300" height="200" xmlns="http://www.w3.org/2000/svg">
       <rect width="100%" height="100%" fill="red" />
       <circle cx="150" cy="100" r="80" fill="green" />
       <text x="150" y="125" font-size="60" text-anchor="middle" fill="white">SVG</text>
-    </svg>`, {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
+    </svg>`,
+		{ window: window }
+	);
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
 
-  t.check(
-    'svg' in ret &&
-    ret.svg.length > 0,
-  "return has svg property")
+	t.check("svg" in ret && ret.svg.length > 0, "return has svg property");
 
-  t.check(
-    Array.isArray(ret.style) &&
-    ret.style[0] === 'html-svg',
-  "svg style");
+	t.check(Array.isArray(ret.style) && ret.style[0] === "html-svg", "svg style");
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("cascade_tags", function(t) {
-  var ret = htmlToPdfMake('<p style="text-align: center;"><span style="font-size: 14px;"><em><strong>test</strong></em></span></p>', {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0].text[0].text[0].text[0];
-  t.check(
-    ret.text === "test" &&
-    ret.bold &&
-    ret.italics &&
-    ret.fontSize === 11 &&
-    ret.alignment === 'center' &&
-    Array.isArray(ret.style) &&
-    ret.style.includes('html-strong') &&
-    ret.style.includes('html-em') &&
-    ret.style.includes('html-span') &&
-    ret.style.includes('html-p'),
-  "cascade_tags");
+test("cascade_tags", function (t) {
+	var ret = htmlToPdfMake(
+		'<p style="text-align: center;"><span style="font-size: 14px;"><em><strong>test</strong></em></span></p>',
+		{ window: window }
+	);
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0].text[0].text[0].text[0];
+	t.check(
+		ret.text === "test" &&
+			ret.bold &&
+			ret.italics &&
+			ret.fontSize === 11 &&
+			ret.alignment === "center" &&
+			Array.isArray(ret.style) &&
+			ret.style.includes("html-strong") &&
+			ret.style.includes("html-em") &&
+			ret.style.includes("html-span") &&
+			ret.style.includes("html-p"),
+		"cascade_tags"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("hr", function(t) {
-  var ret = htmlToPdfMake("<hr>", {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
-  ret = ret[0];
+test("hr", function (t) {
+	var ret = htmlToPdfMake("<hr>", { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
 
-  t.check(
-    !!ret.canvas && ret.canvas.length === 1 && ret.canvas[0].type === "line",
-    "hr tag"
-  );
+	t.check(
+		!!ret.canvas && ret.canvas.length === 1 && ret.canvas[0].type === "line",
+		"hr tag"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("table non empty inside div styles",function(t) {
-  var html = `<table>
+test("table non empty inside div styles", function (t) {
+	var html = `<table>
     <thead>
       <tr>
         <th><div> </div></th>
@@ -641,21 +722,22 @@ test("table non empty inside div styles",function(t) {
       </tr>
     </tbody>
   </table>`;
-  var ret = htmlToPdfMake(html, {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.table &&
-    Array.isArray(ret.table.body) &&
-    ret.table.body[0].length === ret.table.body[1].length,
-    "global");
+	var ret = htmlToPdfMake(html, { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.table &&
+			Array.isArray(ret.table.body) &&
+			ret.table.body[0].length === ret.table.body[1].length,
+		"global"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("table empty inside div header",function(t) {
-  var html = `<table>
+test("table empty inside div header", function (t) {
+	var html = `<table>
     <thead>
       <tr>
         <th><div></div></th>
@@ -673,149 +755,166 @@ test("table empty inside div header",function(t) {
       </tr>
     </tbody>
   </table>`;
-  var ret = htmlToPdfMake(html, {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.table &&
-    Array.isArray(ret.table.body) &&
-    ret.table.body[0].length === ret.table.body[1].length,
-    "global");
+	var ret = htmlToPdfMake(html, { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.table &&
+			Array.isArray(ret.table.body) &&
+			ret.table.body[0].length === ret.table.body[1].length,
+		"global"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("inherit css styles",function(t) {
-  var html = `<div style="color:red;"><span style="color:blue">blue<strong style="color:green">green</strong>blue</span><span>red</span></div>`;
-  var ret = htmlToPdfMake(html, {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.color === 'red' &&
-    Array.isArray(ret.style) &&
-    ret.style.includes('html-div') &&
-    Array.isArray(ret.text) &&
-    Array.isArray(ret.text[0].text) &&
-    ret.text[0].text[0].text === 'blue' &&
-    ret.text[0].text[0].color === 'blue' &&
-    ret.text[0].text[1].text === 'green' &&
-    ret.text[0].text[1].color === 'green' &&
-    ret.text[0].text[1].bold &&
-    ret.text[0].text[2].text === 'blue' &&
-    ret.text[0].text[2].color === 'blue' &&
-    ret.text[0].color === 'blue' &&
-    ret.text[1].text === 'red' &&
-    ret.text[1].color === 'red',
-  "inherit");
+test("inherit css styles", function (t) {
+	var html = `<div style="color:red;"><span style="color:blue">blue<strong style="color:green">green</strong>blue</span><span>red</span></div>`;
+	var ret = htmlToPdfMake(html, { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.color === "red" &&
+			Array.isArray(ret.style) &&
+			ret.style.includes("html-div") &&
+			Array.isArray(ret.text) &&
+			Array.isArray(ret.text[0].text) &&
+			ret.text[0].text[0].text === "blue" &&
+			ret.text[0].text[0].color === "blue" &&
+			ret.text[0].text[1].text === "green" &&
+			ret.text[0].text[1].color === "green" &&
+			ret.text[0].text[1].bold &&
+			ret.text[0].text[2].text === "blue" &&
+			ret.text[0].text[2].color === "blue" &&
+			ret.text[0].color === "blue" &&
+			ret.text[1].text === "red" &&
+			ret.text[1].color === "red",
+		"inherit"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("colored borders", function(t) {
-  var html = `<table><tr><td style="border-top-width: 0; border-right: 1pt solid #0080C0; border-bottom: 0; border-left: 1px solid #0080C0;">Cell with border left and right in blue</td></tr></table>`;
-  var ret = htmlToPdfMake(html, {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(
-    ret.table.body[0][0].text === "Cell with border left and right in blue" &&
-    Array.isArray(ret.table.body[0][0].border) &&
-    ret.table.body[0][0].border[0] &&
-    !ret.table.body[0][0].border[1] &&
-    ret.table.body[0][0].border[2] &&
-    !ret.table.body[0][0].border[3] &&
-    Array.isArray(ret.table.body[0][0].borderColor) &&
-    ret.table.body[0][0].borderColor[0] === '#0080c0' &&
-    ret.table.body[0][0].borderColor[1] === '#000000' &&
-    ret.table.body[0][0].borderColor[2] === '#0080c0' &&
-    ret.table.body[0][0].borderColor[3] === '#000000',
-  "colored borders");
+test("colored borders", function (t) {
+	var html = `<table><tr><td style="border-top-width: 0; border-right: 1pt solid #0080C0; border-bottom: 0; border-left: 1px solid #0080C0;">Cell with border left and right in blue</td></tr></table>`;
+	var ret = htmlToPdfMake(html, { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(
+		ret.table.body[0][0].text === "Cell with border left and right in blue" &&
+			Array.isArray(ret.table.body[0][0].border) &&
+			ret.table.body[0][0].border[0] &&
+			!ret.table.body[0][0].border[1] &&
+			ret.table.body[0][0].border[2] &&
+			!ret.table.body[0][0].border[3] &&
+			Array.isArray(ret.table.body[0][0].borderColor) &&
+			ret.table.body[0][0].borderColor[0] === "#0080c0" &&
+			ret.table.body[0][0].borderColor[1] === "#000000" &&
+			ret.table.body[0][0].borderColor[2] === "#0080c0" &&
+			ret.table.body[0][0].borderColor[3] === "#000000",
+		"colored borders"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("cell with P and DIV", function(t) {
-  var html = `<table><tr><td>some text<p>p1<span>span1</span><span>span2</span></p><p>p2</p><span>span3</span><p><span>p3span4</span></p><div><span>span5</span><p>p4</p></div><strong>strong</strong></td></tr></table>`;
-  var ret = htmlToPdfMake(html, {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0].table.body[0][0];
-  t.check(ret.stack[0].text === "some text", "some text");
-  t.check(ret.stack[1].text[0].text === "p1", "p1");
-  t.check(ret.stack[1].text[1].text === "span1", "span1");
-  t.check(ret.stack[1].text[2].text === "span2", "span2");
-  t.check(ret.stack[2].text === "p2", "p2");
-  t.check(ret.stack[3].text === "span3", "span3");
-  t.check(ret.stack[4].text[0].text === "p3span4", "p3span4");
-  t.check(ret.stack[5].stack[0].text === "span5", "span5");
-  t.check(ret.stack[5].stack[1].text === "p4", "p4");
-  t.check(ret.stack[6].text === "strong", "strong");
+test("cell with P and DIV", function (t) {
+	var html = `<table><tr><td>some text<p>p1<span>span1</span><span>span2</span></p><p>p2</p><span>span3</span><p><span>p3span4</span></p><div><span>span5</span><p>p4</p></div><strong>strong</strong></td></tr></table>`;
+	var ret = htmlToPdfMake(html, { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0].table.body[0][0];
+	t.check(ret.stack[0].text === "some text", "some text");
+	t.check(ret.stack[1].text[0].text === "p1", "p1");
+	t.check(ret.stack[1].text[1].text === "span1", "span1");
+	t.check(ret.stack[1].text[2].text === "span2", "span2");
+	t.check(ret.stack[2].text === "p2", "p2");
+	t.check(ret.stack[3].text === "span3", "span3");
+	t.check(ret.stack[4].text[0].text === "p3span4", "p3span4");
+	t.check(ret.stack[5].stack[0].text === "span5", "span5");
+	t.check(ret.stack[5].stack[1].text === "p4", "p4");
+	t.check(ret.stack[6].text === "strong", "strong");
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("tableAutoSize", function(t) {
-  var html = `<table><tr style="height:100px"><td style="width:350px"></td><td></td></tr><tr><td style="width:100px"></td><td style="height:200px"></td></tr></table>`;
-  var ret = htmlToPdfMake(html, {window:window, tableAutoSize:true});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(
-    Array.isArray(ret.table.widths) &&
-    ret.table.widths.length === 2 &&
-    ret.table.widths[0] === 264 &&
-    ret.table.widths[1] === 'auto' &&
-    ret.table.heights.length === 2 &&
-    ret.table.heights[0] === 75 &&
-    ret.table.heights[1] === 151
-  , "tableAutoSize");
+test("tableAutoSize", function (t) {
+	var html = `<table><tr style="height:100px"><td style="width:350px"></td><td></td></tr><tr><td style="width:100px"></td><td style="height:200px"></td></tr></table>`;
+	var ret = htmlToPdfMake(html, { window: window, tableAutoSize: true });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(
+		Array.isArray(ret.table.widths) &&
+			ret.table.widths.length === 2 &&
+			ret.table.widths[0] === 264 &&
+			ret.table.widths[1] === "auto" &&
+			ret.table.heights.length === 2 &&
+			ret.table.heights[0] === 75 &&
+			ret.table.heights[1] === 151,
+		"tableAutoSize"
+	);
 
-  t.finish();
-})
+	t.finish();
+});
 
-test("convertUnit and stack", function(t) {
-  var html = `<div><div style="font-size:16px;margin-left:12pt">points</div><div style="margin-left:1rem">points</div></div>`;
-  var ret = htmlToPdfMake(html, {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  ret = ret[0];
-  t.check(Array.isArray(ret.stack), "stack");
-  t.check(
-    ret.stack[0].marginLeft===12 &&
-    ret.stack[0].fontSize===12 &&
-    ret.stack[1].marginLeft===12
-  , "convertUnit");
-  t.finish();
-})
+test("convertUnit and stack", function (t) {
+	var html = `<div><div style="font-size:16px;margin-left:12pt">points</div><div style="margin-left:1rem">points</div></div>`;
+	var ret = htmlToPdfMake(html, { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	ret = ret[0];
+	t.check(Array.isArray(ret.stack), "stack");
+	t.check(
+		ret.stack[0].marginLeft === 12 &&
+			ret.stack[0].fontSize === 12 &&
+			ret.stack[1].marginLeft === 12,
+		"convertUnit"
+	);
+	t.finish();
+});
 
-test("'decoration' style", function(t) {
-  var html = `<p><u><s>Test</s></u></p>`;
-  var ret = htmlToPdfMake(html, {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  t.check(Array.isArray(ret[0].text) && ret[0].text.length===1 && Array.isArray(ret[0].text[0].text) && ret[0].text[0].text.length===1, "structure is OK");
-  ret = ret[0].text[0].text[0];
-  t.check(ret.text === "Test", "text is 'Test'");
-  t.check(ret.nodeName === "S", "nodeName is 'S'");
-  t.check(Array.isArray(ret.decoration), "'decoration' is array");
-  t.check(ret.decoration.includes("underline"), "includes 'underline'");
-  t.check(ret.decoration.includes("lineThrough"), "includes 'lineThrough'");
-  t.finish();
-})
+test("'decoration' style", function (t) {
+	var html = `<p><u><s>Test</s></u></p>`;
+	var ret = htmlToPdfMake(html, { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	t.check(
+		Array.isArray(ret[0].text) &&
+			ret[0].text.length === 1 &&
+			Array.isArray(ret[0].text[0].text) &&
+			ret[0].text[0].text.length === 1,
+		"structure is OK"
+	);
+	ret = ret[0].text[0].text[0];
+	t.check(ret.text === "Test", "text is 'Test'");
+	t.check(ret.nodeName === "S", "nodeName is 'S'");
+	t.check(Array.isArray(ret.decoration), "'decoration' is array");
+	t.check(ret.decoration.includes("underline"), "includes 'underline'");
+	t.check(ret.decoration.includes("lineThrough"), "includes 'lineThrough'");
+	t.finish();
+});
 
-test("'decoration' style 2", function(t) {
-  var html = `<p><span style="text-decoration:underline"><span style="text-decoration:line-through">Test</span></span></p>`;
-  var ret = htmlToPdfMake(html, {window:window});
-  if (debug) console.log(JSON.stringify(ret));
-  t.check(Array.isArray(ret) && ret.length===1, "return is OK");
-  t.check(Array.isArray(ret[0].text) && ret[0].text.length===1 && Array.isArray(ret[0].text[0].text) && ret[0].text[0].text.length===1, "structure is OK");
-  ret = ret[0].text[0].text[0];
-  t.check(ret.text === "Test", "text is 'Test'");
-  t.check(ret.nodeName === "SPAN", "nodeName is 'SPAN'");
-  t.check(Array.isArray(ret.decoration), "'decoration' is array");
-  t.check(ret.decoration.includes("underline"), "includes 'underline'");
-  t.check(ret.decoration.includes("lineThrough"), "includes 'lineThrough'");
-  t.finish();
-})
+test("'decoration' style 2", function (t) {
+	var html = `<p><span style="text-decoration:underline"><span style="text-decoration:line-through">Test</span></span></p>`;
+	var ret = htmlToPdfMake(html, { window: window });
+	if (debug) console.log(JSON.stringify(ret));
+	t.check(Array.isArray(ret) && ret.length === 1, "return is OK");
+	t.check(
+		Array.isArray(ret[0].text) &&
+			ret[0].text.length === 1 &&
+			Array.isArray(ret[0].text[0].text) &&
+			ret[0].text[0].text.length === 1,
+		"structure is OK"
+	);
+	ret = ret[0].text[0].text[0];
+	t.check(ret.text === "Test", "text is 'Test'");
+	t.check(ret.nodeName === "SPAN", "nodeName is 'SPAN'");
+	t.check(Array.isArray(ret.decoration), "'decoration' is array");
+	t.check(ret.decoration.includes("underline"), "includes 'underline'");
+	t.check(ret.decoration.includes("lineThrough"), "includes 'lineThrough'");
+	t.finish();
+});


### PR DESCRIPTION
This PR Resolves #72 .

With this PR, the `color` and `size` attributes will be parsed for the `font` element as though they were passed within a `style` attribute.

The color attribute only accept hex values, meaning that named colors like `red`, `gainsboro`, `pink`... are not allowed.
HTML 4's `size` accepts values from 1 to 7 and doesn't stand for a constant value, but rather provides a relative interface that can translate to a constant font size depending on the element's context. A workaround is providing the following default values: _10, 14, 16, 18, 20, 24, 28_.

The user can easily override those defaults by passing an array in the options as follows:

```js
	var ret = htmlToPdfMake(
		"<font color='#ff0033' size='4'>font element</font>",
		{
			window: window,
			fontSizes: [10, 14, 16, 444, 20, 24, 28],
		}
	);
```