### PR TITLE
fix closing tag typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ To apply these special attributes, you have to use the attribute `data-pdfmake` 
 
 <table data-pdfmake="{&quot;widths&quot;:[100,&quot;*&quot;,&quot;auto&quot;],&quot;heights&quot;:40}">
   <tr>
-    <td colspan="3">Table with <b>widths=[100,"*","auto"]</b> and <b>heights=40</b></th>
+    <td colspan="3">Table with <b>widths=[100,"*","auto"]</b> and <b>heights=40</b></td>
   </tr>
   <tr>
     <td>Cell1</td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "html-to-pdfmake",
-  "version": "2.1.5",
+  "version": "2.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "html-to-pdfmake",
-  "version": "2.0.8",
+  "version": "2.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Fixes a closing tag typo in the "Special Properties" section of the README