### PR TITLE
fix: Discard style that contains size in name if not converted to Unit

### DIFF
--- a/index.js
+++ b/index.js
@@ -726,6 +726,8 @@ function htmlToPdfMake(htmlText, options) {
               if (value) {
                 // convert value to a 'pt' when possible
                 var parsedValue = _this.convertToUnit(value);
+                //discard if not converted and is "size"
+                if (parsedValue === false && key.toLowerCase().indexOf("size") >= 0) break;
                 ret.push({key:key, value:(parsedValue === false ? value : parsedValue)});
               }
             }


### PR DESCRIPTION
Dear,
I have identified the following bug when style "font-size: small"
This happened because after converting html to pdfmake the font-size value becomes NaN.

![image](https://user-images.githubusercontent.com/44271732/189427687-cd507184-df98-4a81-aa48-45da150fc713.png)

HTML used:
<span style="background-color: #ffffff; color: #222222; font-family: arial, helvetica, sans-serif; font-size: small;">3 produtos para a Operação</span>