### PR TITLE
remove extra blanks also from UL

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ function htmlToPdfMake(htmlText, options) {
   this.convertHtml = function(htmlText) {
     // Create a HTML DOM tree out of html string
     var parser = new this.wndw.DOMParser();
-    if (this.removeExtraBlanks) htmlText = htmlText.replace(/(<\/?(div|p|h1|h2|h3|h4|h5|h6|li)([^>]+)?>)\s+(<\/?(div|p|h1|h2|h3|h4|h5|h6|li))/gi, "$1$4").replace(/(<\/?(div|p|h1|h2|h3|h4|h5|h6|li)([^>]+)?>)\s+(<\/?(div|p|h1|h2|h3|h4|h5|h6|li))/gi, "$1$4");
+    if (this.removeExtraBlanks) htmlText = htmlText.replace(/(<\/?(div|p|h1|h2|h3|h4|h5|h6|ul|li)([^>]+)?>)\s+(<\/?(div|p|h1|h2|h3|h4|h5|h6|ul|li))/gi, "$1$4").replace(/(<\/?(div|p|h1|h2|h3|h4|h5|h6|ul|li)([^>]+)?>)\s+(<\/?(div|p|h1|h2|h3|h4|h5|h6|ul|li))/gi, "$1$4");
     var parsedHtml = parser.parseFromString(htmlText, 'text/html');
 
     var docDef = this.parseElement(parsedHtml.body, []);


### PR DESCRIPTION
This change aims to remove also extra blanks from UL tags when using the option "removeExtras blanks".

Current behaviour: double lines above and below when converting UL tags
![image](https://user-images.githubusercontent.com/5768289/213945955-2e76cc9c-c796-4454-8495-4e7babfd1971.png)

Expected behaviour: singlelines above and below when converting UL tags
